### PR TITLE
v0.1.2: Squad draft fields, remove phantom PlayerStats fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-03-26
+
+### Added
+
+- 5 new fields on `SquadPlayer`: `draftYear`, `draftPosition`, `draftType`, `debutYear`, `recruitedFrom` — extracted from AFL API squad endpoint
+
+### Removed
+
+- `supercoachPoints` and `brownlowVotes` from `PlayerStats` type — no data source provides these fields
+
 ## [0.1.1] - 2026-03-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fitzroy-ts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "src/index.ts",
   "exports": {

--- a/plans/PROGRESS.txt
+++ b/plans/PROGRESS.txt
@@ -560,3 +560,26 @@ The repository has strong internal organization — source code is well-structur
 - 194 tests passing, typecheck clean.
 
 ---
+
+[Review] 2026-03-26 13:20 UTC - release (blocking)
+
+### Verdict: NEEDS_WORK
+
+### Findings
+
+1. **RL-001**: Version Mismatch - package.json version not updated for v0.1.2
+   - File: package.json:1
+   - Issue: package.json has version "0.1.1" but release target is v0.1.2.
+   - Suggestion: Run `npm version 0.1.2 --no-git-tag-version` or manually update `"version": "0.1.2"` in package.json.
+
+2. **RL-002**: Missing Changelog - No entry for v0.1.2
+   - File: CHANGELOG.md:8
+   - Issue: CHANGELOG.md has an `[Unreleased]` section with the changes but no `[0.1.2]` heading with a date. The release needs a versioned entry.
+   - Suggestion: Change `## [Unreleased]` to `## [0.1.2] - 2026-03-26` in CHANGELOG.md.
+
+3. **RL-003**: Dirty Working Directory - Uncommitted changes present
+   - File: src/types.ts:0
+   - Issue: 7 modified files are uncommitted: CHANGELOG.md, src/api/teams.ts, src/lib/validation.ts, src/transforms/player-stats.ts, src/types.ts, test/transforms/player-stats.test.ts, test/types.test.ts.
+   - Suggestion: Commit all changes before tagging the release.
+
+---

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -70,6 +70,13 @@ export async function fetchSquad(query: SquadQuery): Promise<Result<Squad, Error
     dateOfBirth: p.player.dateOfBirth ? new Date(p.player.dateOfBirth) : null,
     heightCm: p.player.heightInCm ?? null,
     weightKg: p.player.weightInKg ?? null,
+    draftYear: p.player.draftYear ? Number.parseInt(p.player.draftYear, 10) || null : null,
+    draftPosition: p.player.draftPosition
+      ? Number.parseInt(p.player.draftPosition, 10) || null
+      : null,
+    draftType: p.player.draftType ?? null,
+    debutYear: p.player.debutYear ? Number.parseInt(p.player.debutYear, 10) || null : null,
+    recruitedFrom: p.player.recruitedFrom ?? null,
   }));
 
   return ok({

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -479,6 +479,11 @@ export const SquadPlayerInnerSchema = z
     dateOfBirth: z.string().optional(),
     heightInCm: z.number().optional(),
     weightInKg: z.number().optional(),
+    draftYear: z.string().optional(),
+    draftPosition: z.string().optional(),
+    draftType: z.string().optional(),
+    debutYear: z.string().optional(),
+    recruitedFrom: z.string().optional(),
   })
   .passthrough();
 

--- a/src/transforms/player-stats.ts
+++ b/src/transforms/player-stats.ts
@@ -80,8 +80,6 @@ function transformOne(
     ratingPoints: toNullable(stats.ratingPoints),
 
     dreamTeamPoints: toNullable(stats.dreamTeamPoints),
-    supercoachPoints: null,
-    brownlowVotes: null,
 
     effectiveDisposals: toNullable(stats.extendedStats?.effectiveDisposals),
     effectiveKicks: toNullable(stats.extendedStats?.effectiveKicks),

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,10 +161,8 @@ export interface PlayerStats {
   readonly timeOnGroundPercentage: number | null;
   readonly ratingPoints: number | null;
 
-  /** Fantasy and awards. */
+  /** Fantasy. */
   readonly dreamTeamPoints: number | null;
-  readonly supercoachPoints: number | null;
-  readonly brownlowVotes: number | null;
 
   /** Extended stats. */
   readonly effectiveDisposals: number | null;
@@ -293,6 +291,11 @@ export interface SquadPlayer {
   readonly dateOfBirth: Date | null;
   readonly heightCm: number | null;
   readonly weightKg: number | null;
+  readonly draftYear: number | null;
+  readonly draftPosition: number | null;
+  readonly draftType: string | null;
+  readonly debutYear: number | null;
+  readonly recruitedFrom: string | null;
 }
 
 /** A team's squad for a given season. */

--- a/test/transforms/player-stats.test.ts
+++ b/test/transforms/player-stats.test.ts
@@ -163,10 +163,4 @@ describe("transformPlayerStats", () => {
     };
     expect(transformPlayerStats(list, "CD_M1", 2025, 1, "AFLM")).toEqual([]);
   });
-
-  it("always sets supercoachPoints and brownlowVotes to null", () => {
-    const results = transformPlayerStats(makeStatsList(), "CD_M1", 2025, 1, "AFLM");
-    expect(results[0]?.supercoachPoints).toBeNull();
-    expect(results[0]?.brownlowVotes).toBeNull();
-  });
 });

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -156,8 +156,6 @@ describe("domain types", () => {
       disposalEfficiency: 73.3,
       metresGained: 450,
       dreamTeamPoints: 120,
-      supercoachPoints: 115,
-      brownlowVotes: null,
       source: "afl-api",
     };
     expect(stats.disposals).toBe(30);
@@ -244,6 +242,11 @@ describe("domain types", () => {
       dateOfBirth: new Date("1990-04-05"),
       heightCm: 189,
       weightKg: 92,
+      draftYear: 2007,
+      draftPosition: 10,
+      draftType: "nationalDraft",
+      debutYear: 2008,
+      recruitedFrom: "Moggs Creek (Vic)",
     };
     const squad: Squad = {
       teamId: "CD_T10",


### PR DESCRIPTION
## Summary

- **#11 (fixed):** Extract `draftYear`, `draftPosition`, `draftType`, `debutYear`, `recruitedFrom` from AFL API squad endpoint — these fields were present in the API response but silently dropped by the Zod schema
- **#14 (closed):** Remove `supercoachPoints` and `brownlowVotes` from `PlayerStats` type — confirmed no data source provides these fields
- **#13 (closed):** Attendance already works on FootyWire and AFL Tables sources; AFL API genuinely doesn't return it

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run check` passes (pre-existing lint in `comparison/` dir only)
- [x] `npm run test` — 193 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)