### PR TITLE
fix: handle AEDT (UTC+11) in parseFootyWireDate

### DIFF
--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -95,9 +95,7 @@ export function parseFootyWireDate(dateStr: string, defaultYear?: number): Date 
     if (ampm.toLowerCase() === "pm" && aestHours < 12) aestHours += 12;
     if (ampm.toLowerCase() === "am" && aestHours === 12) aestHours = 0;
 
-    // Date.UTC normalises out-of-range values, so negative hours from
-    // the AEST->UTC offset correctly roll back the day.
-    const date = new Date(Date.UTC(defaultYear, monthIndex, day, aestHours - 10, minutes));
+    const date = melbourneLocalToUtc(defaultYear, monthIndex, day, aestHours, minutes);
     if (Number.isNaN(date.getTime())) return null;
     return date;
   }
@@ -234,6 +232,38 @@ const MONTH_ABBREV_TO_INDEX: ReadonlyMap<string, number> = new Map([
   ["november", 10],
   ["december", 11],
 ]);
+
+/**
+ * Convert a Melbourne local time to a UTC Date, correctly handling both
+ * AEST (UTC+10) and AEDT (UTC+11) via Intl.DateTimeFormat.
+ */
+function melbourneLocalToUtc(
+  year: number,
+  monthIndex: number,
+  day: number,
+  hours: number,
+  minutes: number,
+): Date {
+  // First guess: AEST (UTC+10) — covers most of the AFL season
+  const aestGuess = new Date(Date.UTC(year, monthIndex, day, hours - 10, minutes));
+
+  const parts = new Intl.DateTimeFormat("en-AU", {
+    timeZone: "Australia/Melbourne",
+    day: "2-digit",
+    hour: "2-digit",
+    hour12: false,
+  }).formatToParts(aestGuess);
+
+  const getNum = (type: string) =>
+    Number(parts.find((p) => p.type === type)?.value);
+
+  if (getNum("day") === day && getNum("hour") === (hours % 24)) {
+    return aestGuess;
+  }
+
+  // AEDT (UTC+11)
+  return new Date(Date.UTC(year, monthIndex, day, hours - 11, minutes));
+}
 
 function buildUtcDate(year: number, monthStr: string, day: number): Date | null {
   const monthIndex = MONTH_ABBREV_TO_INDEX.get(monthStr.toLowerCase());

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -254,10 +254,9 @@ function melbourneLocalToUtc(
     hour12: false,
   }).formatToParts(aestGuess);
 
-  const getNum = (type: string) =>
-    Number(parts.find((p) => p.type === type)?.value);
+  const getNum = (type: string) => Number(parts.find((p) => p.type === type)?.value);
 
-  if (getNum("day") === day && getNum("hour") === (hours % 24)) {
+  if (getNum("day") === day && getNum("hour") === hours % 24) {
     return aestGuess;
   }
 

--- a/test/lib/date-utils.test.ts
+++ b/test/lib/date-utils.test.ts
@@ -40,12 +40,16 @@ describe("parseFootyWireDate", () => {
     expect(parseFootyWireDate(input)).toBeNull();
   });
 
-  it("parses time with defaultYear (7:30pm AEST)", () => {
+  it("parses time during AEDT (UTC+11) correctly", () => {
+    // March 13 2025 is during AEDT — 7:30pm AEDT = 08:30 UTC
     const date = parseFootyWireDate("Thu 13 Mar 7:30pm", 2025);
-    expect(date).toBeInstanceOf(Date);
-    expect(date?.getUTCFullYear()).toBe(2025);
-    expect(date?.getUTCMonth()).toBe(2); // March
-    expect(date?.getUTCDate()).toBe(13);
+    expect(date?.toISOString()).toBe("2025-03-13T08:30:00.000Z");
+  });
+
+  it("parses time during AEST (UTC+10) correctly", () => {
+    // July 13 2025 is during AEST — 7:30pm AEST = 09:30 UTC
+    const date = parseFootyWireDate("13 Jul 7:30pm", 2025);
+    expect(date?.toISOString()).toBe("2025-07-13T09:30:00.000Z");
   });
 
   it("parses date-only with defaultYear", () => {
@@ -53,9 +57,9 @@ describe("parseFootyWireDate", () => {
   });
 
   it("parses am time with defaultYear", () => {
+    // April 1 2025 is during AEDT — 11:00am AEDT = 00:00 UTC
     const date = parseFootyWireDate("1 Apr 11:00am", 2025);
-    expect(date).toBeInstanceOf(Date);
-    expect(date?.getUTCMonth()).toBe(3); // April
+    expect(date?.toISOString()).toBe("2025-04-01T00:00:00.000Z");
   });
 
   it.each(["13 Mar 7:30pm", "13 Mar"])("returns null for %j without defaultYear", (input) => {


### PR DESCRIPTION
## Summary
- `parseFootyWireDate` hardcoded a UTC+10 (AEST) offset, making fixture times 1 hour off during daylight saving (Oct–Apr, when Melbourne is UTC+11 AEDT)
- Uses `Intl.DateTimeFormat` with `Australia/Melbourne` to resolve the correct offset automatically — same pattern already used by `toAestString` in the same file
- Tests now assert exact UTC hours for both AEST and AEDT scenarios (previously only checked year/month/day, missing the bug)

Closes #71

## Test plan
- [x] Existing 252 tests pass
- [x] New test: AEDT time `"Thu 13 Mar 7:30pm"` → `2025-03-13T08:30:00.000Z` (was incorrectly `09:30`)
- [x] New test: AEST time `"13 Jul 7:30pm"` → `2025-07-13T09:30:00.000Z` (unchanged, was already correct)
- [x] Updated test: `"1 Apr 11:00am"` → `2025-04-01T00:00:00.000Z` (AEDT, was 1hr off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)