### PR TITLE
feat: Sir Doug Nicholls Round indigenous team-name aliases (v2.2.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,4 @@ jobs:
         run: npm pack --dry-run
 
       - name: Check type exports
-        run: bunx @arethetypeswrong/cli --pack . --ignore-rules cjs-resolves-to-esm
+        run: bunx attw --pack . --ignore-rules cjs-resolves-to-esm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         run: npm pack --dry-run
 
       - name: Check type exports
-        run: bunx @arethetypeswrong/cli --pack . --ignore-rules cjs-resolves-to-esm
+        run: bunx attw --pack . --ignore-rules cjs-resolves-to-esm
 
   publish-npm:
     needs: [check]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-05-22
+
 ### Added
 
 - Sir Doug Nicholls Round (SDNR) indigenous team names returned by the AFL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Sir Doug Nicholls Round (SDNR) indigenous team names returned by the AFL
+  API are now resolved to their canonical club names. `Kuwarna`, `Walyalup`,
+  `Narrm`, `Yartapuulti`, `Euro-Yroke`, and `Waalitj Marawar` are registered
+  as aliases alongside existing nicknames and abbreviations, so they are
+  accepted as `--team` input on the CLI and as `MatchQuery.team` in the
+  library, and they canonicalise automatically in `homeTeam`/`awayTeam`
+  fields across all sources. Output is always the canonical club name.
+
 ## [2.1.0] - 2026-05-09
 
 This release closes 43 issues from an adversarial review of v2.0

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@arethetypeswrong/cli": "^0.18.2",
         "@biomejs/biome": "^2.4.9",
         "@types/node": "^25.5.0",
         "bunup": "^0.16.31",
@@ -22,7 +23,16 @@
       },
     },
   },
+  "overrides": {
+    "fflate": "0.8.2",
+  },
   "packages": {
+    "@andrewbranch/untar.js": ["@andrewbranch/untar.js@1.0.3", "", {}, "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw=="],
+
+    "@arethetypeswrong/cli": ["@arethetypeswrong/cli@0.18.2", "", { "dependencies": { "@arethetypeswrong/core": "0.18.2", "chalk": "^4.1.2", "cli-table3": "^0.6.3", "commander": "^10.0.1", "marked": "^9.1.2", "marked-terminal": "^7.1.0", "semver": "^7.5.4" }, "bin": { "attw": "dist/index.js" } }, "sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw=="],
+
+    "@arethetypeswrong/core": ["@arethetypeswrong/core@0.18.2", "", { "dependencies": { "@andrewbranch/untar.js": "^1.0.3", "@loaderkit/resolve": "^1.0.2", "cjs-module-lexer": "^1.2.3", "fflate": "^0.8.2", "lru-cache": "^11.0.1", "semver": "^7.5.4", "typescript": "5.6.1-rc", "validate-npm-package-name": "^5.0.0" } }, "sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg=="],
+
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
@@ -49,6 +59,8 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.9", "", { "os": "win32", "cpu": "x64" }, "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w=="],
 
+    "@braidai/lang": ["@braidai/lang@1.1.2", "", {}, "sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA=="],
+
     "@bunup/dts": ["@bunup/dts@0.14.53", "", { "dependencies": { "@babel/parser": "^7.28.6", "coffi": "^0.1.37", "oxc-minify": "^0.93.0", "oxc-resolver": "^11.16.2", "oxc-transform": "^0.93.0", "picocolors": "^1.1.1", "std-env": "^3.10.0", "ts-import-resolver": "^0.1.23" }, "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-qyHgYEYxcghoChICEhuFKfA/EqqRA9WHOHLXcIkR9c70DgLAEXcOlkYhfBPmGxfMKJYL0X4VtQwst0/AMk9D3g=="],
 
     "@bunup/shared": ["@bunup/shared@0.16.28", "", { "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-6xyJB5/OFYf0tLCQSRL+PrgzYlS0KabysM06cBY0Ijuk1tr5Aak8/NqzE6ifu+s6K0mstnGXQ+6DqtNlOMEazw=="],
@@ -56,6 +68,8 @@
     "@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
 
     "@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
+
+    "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
@@ -118,6 +132,8 @@
     "@jackemcpherson/rds-js": ["@jackemcpherson/rds-js@0.2.0", "", {}, "sha512-YMaai5MFEM+KwfkhetiQR5Q/mJUzJu7HntjSj++3hG8hVcpSUgsAcd0Q3TVSvCiT2lOM3Qf6MmYarfmiWDoMgQ=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@loaderkit/resolve": ["@loaderkit/resolve@1.0.6", "", { "dependencies": { "@braidai/lang": "^1.0.0" } }, "sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
@@ -255,6 +271,8 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.11", "", {}, "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ=="],
 
+    "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
@@ -281,6 +299,14 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.1", "", { "dependencies": { "@vitest/pretty-format": "4.1.1", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.0.3" } }, "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ=="],
 
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
@@ -288,6 +314,10 @@
     "bunup": ["bunup@0.16.31", "", { "dependencies": { "@bunup/dts": "^0.14.53", "@bunup/shared": "0.16.28", "chokidar": "^5.0.0", "coffi": "^0.1.37", "lightningcss": "^1.30.2", "picocolors": "^1.1.1", "tinyexec": "^1.0.2", "tree-kill": "^1.2.2", "zlye": "^0.4.4" }, "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"], "bin": { "bunup": "dist/cli/index.js" } }, "sha512-gWspdmLyso6DQwuNCbUL+hUrHST+8B/vl6woLryJfndjfRpdSKRKtS9wNbKCRPztY1VcubUjcIh6sCM8F3MYlQ=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
 
     "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
 
@@ -297,7 +327,21 @@
 
     "citty": ["citty@0.2.1", "", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
 
+    "cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
+
+    "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
+
+    "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
+
+    "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
+
     "coffi": ["coffi@0.1.37", "", { "dependencies": { "strip-json-comments": "^5.0.3" } }, "sha512-ewO5Xis7sw7g54yI/3lJ/nNV90Er4ZnENeDORZjrs58T70MmwKFLZgevraNCz+RmB4KDKsYT1ui1wDB36iPWqQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -315,13 +359,21 @@
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "emojilib": ["emojilib@2.4.0", "", {}, "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="],
+
     "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
 
     "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -329,13 +381,23 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -361,11 +423,23 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "lru-cache": ["lru-cache@11.5.0", "", {}, "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "marked": ["marked@9.1.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q=="],
+
+    "marked-terminal": ["marked-terminal@7.3.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "ansi-regex": "^6.1.0", "chalk": "^5.4.1", "cli-highlight": "^2.1.11", "cli-table3": "^0.6.5", "node-emoji": "^2.2.0", "supports-hyperlinks": "^3.1.0" }, "peerDependencies": { "marked": ">=1 <16" } }, "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw=="],
+
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "node-emoji": ["node-emoji@2.2.0", "", { "dependencies": { "@sindresorhus/is": "^4.6.0", "char-regex": "^1.0.2", "emojilib": "^2.4.0", "skin-tone": "^2.0.0" } }, "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw=="],
+
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
@@ -391,15 +465,21 @@
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "rolldown": ["rolldown@1.0.0-rc.11", "", { "dependencies": { "@oxc-project/types": "=0.122.0", "@rolldown/pluginutils": "1.0.0-rc.11" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.11", "@rolldown/binding-darwin-arm64": "1.0.0-rc.11", "@rolldown/binding-darwin-x64": "1.0.0-rc.11", "@rolldown/binding-freebsd-x64": "1.0.0-rc.11", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
+    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "skin-tone": ["skin-tone@2.0.0", "", { "dependencies": { "unicode-emoji-modifier-base": "^1.0.0" } }, "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -407,7 +487,19 @@
 
     "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "supports-hyperlinks": ["supports-hyperlinks@3.2.0", "", { "dependencies": { "has-flag": "^4.0.0", "supports-color": "^7.0.0" } }, "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -431,6 +523,10 @@
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
+    "unicode-emoji-modifier-base": ["unicode-emoji-modifier-base@1.0.0", "", {}, "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="],
+
+    "validate-npm-package-name": ["validate-npm-package-name@5.0.1", "", {}, "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ=="],
+
     "vite": ["vite@8.0.2", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.11", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA=="],
 
     "vitest": ["vitest@4.1.1", "", { "dependencies": { "@vitest/expect": "4.1.1", "@vitest/mocker": "4.1.1", "@vitest/pretty-format": "4.1.1", "@vitest/runner": "4.1.1", "@vitest/snapshot": "4.1.1", "@vitest/spy": "4.1.1", "@vitest/utils": "4.1.1", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.1", "@vitest/browser-preview": "4.1.1", "@vitest/browser-webdriverio": "4.1.1", "@vitest/ui": "4.1.1", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA=="],
@@ -441,14 +537,34 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
+
+    "yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+
     "zlye": ["zlye@0.4.4", "", { "dependencies": { "picocolors": "^1.1.1" }, "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-fwpeC841X3ElOLYRMKXbwX29pitNrsm6nRNvEhDMrRXDl3BhR2i03Bkr0GNrpyYgZJuEzUsBylXAYzgGPXXOCQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "@arethetypeswrong/core/typescript": ["typescript@5.6.1-rc", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ=="],
+
     "@bunup/dts/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "cli-highlight/parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
+
+    "cli-highlight/parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
+    "marked-terminal/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "cli-highlight/parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fitzroy",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "TypeScript port of the fitzRoy R package — programmatic access to AFL data including match results, player stats, fixtures, ladders, and more",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -51,11 +51,15 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.2",
     "@biomejs/biome": "^2.4.9",
     "@types/node": "^25.5.0",
     "bunup": "^0.16.31",
     "esbuild": "^0.27.4",
     "typescript": "^6.0.2",
     "vitest": "^4.1.1"
+  },
+  "overrides": {
+    "fflate": "0.8.2"
   }
 }

--- a/src/lib/team-mapping.ts
+++ b/src/lib/team-mapping.ts
@@ -4,12 +4,18 @@
  * Maps abbreviations, short names, and historical names to the canonical
  * AFL API team names. Lookups are case-insensitive.
  *
+ * Indigenous names used by participating clubs during the AFL's Sir Doug
+ * Nicholls Round (e.g. `"Walyalup"` for Fremantle) are also registered as
+ * aliases, so they canonicalise to the standard club name in both directions
+ * — accepted on input filters and resolved in upstream payloads.
+ *
  * @example
  * ```ts
  * normaliseTeamName("GWS");           // "GWS Giants"
  * normaliseTeamName("footscray");     // "Western Bulldogs"
  * normaliseTeamName("KANGAROOS");     // "North Melbourne"
  * normaliseTeamName("Sydney");        // "Sydney Swans"
+ * normaliseTeamName("Walyalup");      // "Fremantle"
  * ```
  */
 
@@ -18,12 +24,12 @@
  * The first element of each tuple is the canonical name.
  */
 const TEAM_ALIASES: ReadonlyArray<readonly [canonical: string, ...aliases: string[]]> = [
-  ["Adelaide Crows", "Adelaide", "Crows", "ADEL", "AD"],
+  ["Adelaide Crows", "Adelaide", "Crows", "Kuwarna", "ADEL", "AD"],
   ["Brisbane Lions", "Brisbane", "Brisbane Bears", "Bears", "Lions", "Fitzroy Lions", "BL", "BRIS"],
   ["Carlton", "Carlton Blues", "Blues", "CARL", "CA"],
   ["Collingwood", "Collingwood Magpies", "Magpies", "COLL", "CW"],
   ["Essendon", "Essendon Bombers", "Bombers", "ESS", "ES"],
-  ["Fremantle", "Fremantle Dockers", "Dockers", "FRE", "FR"],
+  ["Fremantle", "Fremantle Dockers", "Dockers", "Walyalup", "FRE", "FR"],
   ["Geelong Cats", "Geelong", "Cats", "GEEL", "GE"],
   [
     "Gold Coast Suns",
@@ -44,13 +50,13 @@ const TEAM_ALIASES: ReadonlyArray<readonly [canonical: string, ...aliases: strin
     "GW",
   ],
   ["Hawthorn", "Hawthorn Hawks", "Hawks", "HAW", "HW"],
-  ["Melbourne", "Melbourne Demons", "Demons", "MELB", "ME"],
+  ["Melbourne", "Melbourne Demons", "Demons", "Narrm", "MELB", "ME"],
   ["North Melbourne", "North Melbourne Kangaroos", "Kangaroos", "Kangas", "North", "NMFC", "NM"],
-  ["Port Adelaide", "Port Adelaide Power", "Power", "Port", "PA", "PAFC"],
+  ["Port Adelaide", "Port Adelaide Power", "Power", "Port", "Yartapuulti", "PA", "PAFC"],
   ["Richmond", "Richmond Tigers", "Tigers", "RICH", "RI"],
-  ["St Kilda", "St Kilda Saints", "Saints", "Saint Kilda", "STK", "SK"],
+  ["St Kilda", "St Kilda Saints", "Saints", "Saint Kilda", "Euro-Yroke", "STK", "SK"],
   ["Sydney Swans", "Sydney", "Swans", "South Melbourne", "South Melbourne Swans", "SYD", "SY"],
-  ["West Coast Eagles", "West Coast", "Eagles", "WCE", "WC"],
+  ["West Coast Eagles", "West Coast", "Eagles", "Waalitj Marawar", "WCE", "WC"],
   ["Western Bulldogs", "Bulldogs", "Footscray", "Footscray Bulldogs", "WB", "WBD"],
 
   // Historical / defunct VFL teams

--- a/test/fixtures/afl-api-round-10-2026.json
+++ b/test/fixtures/afl-api-round-10-2026.json
@@ -1,0 +1,1986 @@
+{
+  "roundId": "CD_R202601410",
+  "byes": [],
+  "items": [
+    {
+      "match": {
+        "name": "Brisbane Lions Vs Geelong Cats",
+        "date": "2026-05-14T09:30:00.000+0000",
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141001",
+        "venue": "CD_V20",
+        "utcStartTime": "2026-05-14T09:30:00",
+        "homeTeamId": "CD_T20",
+        "awayTeamId": "CD_T70",
+        "homeTeam": {
+          "name": "Brisbane Lions",
+          "timeZone": null,
+          "teamId": "CD_T20",
+          "abbr": "BL",
+          "nickname": "Lions",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_logos/400x400/brisbane_a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_flags/small/Brisbane.png"
+        },
+        "awayTeam": {
+          "name": "Geelong Cats",
+          "timeZone": null,
+          "teamId": "CD_T70",
+          "abbr": "GEEL",
+          "nickname": "Cats",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_logos/400x400/geelong_a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_flags/small/Geelong.png"
+        },
+        "round": "CD_R202601410",
+        "venueLocalStartTime": "2026-05-14T19:30:00",
+        "abbr": "BL V GEEL",
+        "thanksTicketLink": null,
+        "twitterHashTag": "#afllionscats"
+      },
+      "venue": {
+        "address": "Brisbane",
+        "name": "Gabba",
+        "state": "QLD",
+        "timeZone": "Australia/Brisbane",
+        "venueId": "CD_V20",
+        "abbreviation": "G",
+        "imageURL": null,
+        "capacity": null,
+        "groundDimension": null,
+        "latitude": null,
+        "longitude": null,
+        "ticketProviderLink": null,
+        "androidStadiumLink": null,
+        "iosStadiumLink": null,
+        "landOwner": "Yuggera - Turrbal"
+      },
+      "round": {
+        "name": "Round 10",
+        "year": "2026",
+        "roundId": "CD_R202601410",
+        "abbreviation": "Rd 10",
+        "competitionId": "CD_S2026014",
+        "roundNumber": 10
+      },
+      "liveVideos": [],
+      "score": {
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141001",
+        "homeTeamScore": {
+          "matchScore": {
+            "totalScore": 76,
+            "goals": 11,
+            "behinds": 10,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 13,
+                "goals": 2,
+                "behinds": 1,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 32,
+                "goals": 5,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 21,
+                "goals": 3,
+                "behinds": 3,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 10,
+                "goals": 1,
+                "behinds": 4,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 1,
+          "minutesInFront": 0
+        },
+        "awayTeamScore": {
+          "matchScore": {
+            "totalScore": 117,
+            "goals": 17,
+            "behinds": 15,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 35,
+                "goals": 5,
+                "behinds": 5,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 22,
+                "goals": 3,
+                "behinds": 4,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 38,
+                "goals": 6,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 22,
+                "goals": 3,
+                "behinds": 4,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 3,
+          "minutesInFront": 121
+        },
+        "matchClock": {
+          "periods": [
+            {
+              "periodNumber": 1,
+              "periodSeconds": 2081,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 2,
+              "periodSeconds": 1937,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 3,
+              "periodSeconds": 2013,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 4,
+              "periodSeconds": 1640,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            }
+          ]
+        },
+        "weather": {
+          "description": "Showers",
+          "tempInCelsius": 24,
+          "weatherType": "RAIN"
+        },
+        "scoreWorm": null,
+        "scoreMap": null,
+        "homeTeamScoreChart": {
+          "goals": 11,
+          "leftBehinds": 1,
+          "rightBehinds": 3,
+          "leftPosters": 1,
+          "rightPosters": 2,
+          "rushedBehinds": 1,
+          "touchedBehinds": 2
+        },
+        "awayTeamScoreChart": {
+          "goals": 17,
+          "leftBehinds": 4,
+          "rightBehinds": 4,
+          "leftPosters": 1,
+          "rightPosters": 1,
+          "rushedBehinds": 3,
+          "touchedBehinds": 2
+        },
+        "lastUpdated": "2026-05-14T12:36:50.223+0000"
+      },
+      "k2kSponsored": false
+    },
+    {
+      "match": {
+        "name": "Sydney Swans Vs Collingwood",
+        "date": "2026-05-15T09:30:00.000+0000",
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141002",
+        "venue": "CD_V60",
+        "utcStartTime": "2026-05-15T09:30:00",
+        "homeTeamId": "CD_T160",
+        "awayTeamId": "CD_T40",
+        "homeTeam": {
+          "name": "Sydney Swans",
+          "timeZone": null,
+          "teamId": "CD_T160",
+          "abbr": "SYD",
+          "nickname": "Swans",
+          "badgeAssetURL": "https://resources.afl.com.au/afl/photo/2020/11/18/6f409f02-2e1c-403a-8164-132a9178ccf5/Sydney-Swans-A.png",
+          "flagAssetURL": "https://resources.afl.com.au/afl/photo/2020/11/18/14fda5d8-4b35-4352-8076-c1fa3075f9a4/Sydney-Swans-Flag.png"
+        },
+        "awayTeam": {
+          "name": "Collingwood",
+          "timeZone": null,
+          "teamId": "CD_T40",
+          "abbr": "COLL",
+          "nickname": "Magpies",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_logos/400x400/collingwood_a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_flags/small/Collingwood.png"
+        },
+        "round": "CD_R202601410",
+        "venueLocalStartTime": "2026-05-15T19:30:00",
+        "abbr": "SYD V COLL",
+        "thanksTicketLink": null,
+        "twitterHashTag": "#aflswanspies"
+      },
+      "venue": {
+        "address": "Sydney",
+        "name": "SCG",
+        "state": "NSW",
+        "timeZone": "Australia/Sydney",
+        "venueId": "CD_V60",
+        "abbreviation": "SCG",
+        "imageURL": null,
+        "capacity": null,
+        "groundDimension": null,
+        "latitude": null,
+        "longitude": null,
+        "ticketProviderLink": null,
+        "androidStadiumLink": null,
+        "iosStadiumLink": null,
+        "landOwner": "Gadigal"
+      },
+      "round": {
+        "name": "Round 10",
+        "year": "2026",
+        "roundId": "CD_R202601410",
+        "abbreviation": "Rd 10",
+        "competitionId": "CD_S2026014",
+        "roundNumber": 10
+      },
+      "liveVideos": [],
+      "score": {
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141002",
+        "homeTeamScore": {
+          "matchScore": {
+            "totalScore": 81,
+            "goals": 11,
+            "behinds": 15,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 10,
+                "goals": 1,
+                "behinds": 4,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 14,
+                "goals": 2,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 42,
+                "goals": 6,
+                "behinds": 6,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 15,
+                "goals": 2,
+                "behinds": 3,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 2,
+          "minutesInFront": 30
+        },
+        "awayTeamScore": {
+          "matchScore": {
+            "totalScore": 75,
+            "goals": 10,
+            "behinds": 15,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 32,
+                "goals": 5,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 13,
+                "goals": 1,
+                "behinds": 7,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 15,
+                "goals": 2,
+                "behinds": 3,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 15,
+                "goals": 2,
+                "behinds": 3,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 4,
+          "minutesInFront": 97
+        },
+        "matchClock": {
+          "periods": [
+            {
+              "periodNumber": 1,
+              "periodSeconds": 1846,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 2,
+              "periodSeconds": 1996,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 3,
+              "periodSeconds": 2095,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 4,
+              "periodSeconds": 1871,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            }
+          ]
+        },
+        "weather": {
+          "description": "Showers",
+          "tempInCelsius": 22,
+          "weatherType": "RAIN"
+        },
+        "scoreWorm": null,
+        "scoreMap": null,
+        "homeTeamScoreChart": {
+          "goals": 11,
+          "leftBehinds": 6,
+          "rightBehinds": 7,
+          "leftPosters": 0,
+          "rightPosters": 0,
+          "rushedBehinds": 2,
+          "touchedBehinds": 0
+        },
+        "awayTeamScoreChart": {
+          "goals": 10,
+          "leftBehinds": 5,
+          "rightBehinds": 6,
+          "leftPosters": 0,
+          "rightPosters": 0,
+          "rushedBehinds": 4,
+          "touchedBehinds": 0
+        },
+        "lastUpdated": "2026-05-15T12:52:20.759+0000"
+      },
+      "k2kSponsored": false
+    },
+    {
+      "match": {
+        "name": "Gold Coast SUNS Vs Yartapuulti",
+        "date": "2026-05-15T10:10:00.000+0000",
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141003",
+        "venue": "CD_V160",
+        "utcStartTime": "2026-05-15T10:10:00",
+        "homeTeamId": "CD_T1000",
+        "awayTeamId": "CD_T110",
+        "homeTeam": {
+          "name": "Gold Coast SUNS",
+          "timeZone": null,
+          "teamId": "CD_T1000",
+          "abbr": "GCFC",
+          "nickname": "SUNS",
+          "badgeAssetURL": "https://resources.afl.com.au/afl/photo/2024/11/06/16858184-4d3f-49ec-9346-c949970f6b07/GCS_logo_A.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/GC-flag-sml.png"
+        },
+        "awayTeam": {
+          "name": "Yartapuulti",
+          "timeZone": null,
+          "teamId": "CD_T110",
+          "abbr": "PORT",
+          "nickname": "Power",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/Port-logo-a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/flag-port-adelaide-sml.png"
+        },
+        "round": "CD_R202601410",
+        "venueLocalStartTime": "2026-05-15T19:40:00",
+        "abbr": "GCFC V PORT",
+        "thanksTicketLink": null,
+        "twitterHashTag": "#aflsunspower"
+      },
+      "venue": {
+        "address": "Darwin",
+        "name": "TIO Stadium",
+        "state": "NT",
+        "timeZone": "Australia/Darwin",
+        "venueId": "CD_V160",
+        "abbreviation": "TIO",
+        "imageURL": null,
+        "capacity": null,
+        "groundDimension": null,
+        "latitude": null,
+        "longitude": null,
+        "ticketProviderLink": null,
+        "androidStadiumLink": null,
+        "iosStadiumLink": null,
+        "landOwner": "Larrakia"
+      },
+      "round": {
+        "name": "Round 10",
+        "year": "2026",
+        "roundId": "CD_R202601410",
+        "abbreviation": "Rd 10",
+        "competitionId": "CD_S2026014",
+        "roundNumber": 10
+      },
+      "liveVideos": [],
+      "score": {
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141003",
+        "homeTeamScore": {
+          "matchScore": {
+            "totalScore": 98,
+            "goals": 15,
+            "behinds": 8,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 32,
+                "goals": 5,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 37,
+                "goals": 6,
+                "behinds": 1,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 21,
+                "goals": 3,
+                "behinds": 3,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 8,
+                "goals": 1,
+                "behinds": 2,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 2,
+          "minutesInFront": 116
+        },
+        "awayTeamScore": {
+          "matchScore": {
+            "totalScore": 73,
+            "goals": 10,
+            "behinds": 13,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 16,
+                "goals": 2,
+                "behinds": 4,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 26,
+                "goals": 4,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 8,
+                "goals": 1,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 23,
+                "goals": 3,
+                "behinds": 5,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 2,
+          "minutesInFront": 7
+        },
+        "matchClock": {
+          "periods": [
+            {
+              "periodNumber": 1,
+              "periodSeconds": 1849,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 2,
+              "periodSeconds": 1983,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 3,
+              "periodSeconds": 1847,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 4,
+              "periodSeconds": 1914,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            }
+          ]
+        },
+        "weather": {
+          "description": "Mostly sunny",
+          "tempInCelsius": 33,
+          "weatherType": "MOSTLY_SUNNY"
+        },
+        "scoreWorm": null,
+        "scoreMap": null,
+        "homeTeamScoreChart": {
+          "goals": 15,
+          "leftBehinds": 2,
+          "rightBehinds": 2,
+          "leftPosters": 0,
+          "rightPosters": 1,
+          "rushedBehinds": 2,
+          "touchedBehinds": 1
+        },
+        "awayTeamScoreChart": {
+          "goals": 10,
+          "leftBehinds": 6,
+          "rightBehinds": 2,
+          "leftPosters": 2,
+          "rightPosters": 1,
+          "rushedBehinds": 2,
+          "touchedBehinds": 0
+        },
+        "lastUpdated": "2026-05-15T13:08:17.433+0000"
+      },
+      "k2kSponsored": false
+    },
+    {
+      "match": {
+        "name": "Kuwarna Vs North Melbourne",
+        "date": "2026-05-16T03:15:00.000+0000",
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141004",
+        "venue": "CD_V6",
+        "utcStartTime": "2026-05-16T03:15:00",
+        "homeTeamId": "CD_T10",
+        "awayTeamId": "CD_T100",
+        "homeTeam": {
+          "name": "Kuwarna",
+          "timeZone": null,
+          "teamId": "CD_T10",
+          "abbr": "ADEL",
+          "nickname": "Crows",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_logos/400x400/adelaide_a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_flags/small/Adelaide.png"
+        },
+        "awayTeam": {
+          "name": "North Melbourne",
+          "timeZone": null,
+          "teamId": "CD_T100",
+          "abbr": "NMFC",
+          "nickname": "Kangaroos",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_logos/400x400/north_melbourne_a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_flags/small/North-Melbourne.png"
+        },
+        "round": "CD_R202601410",
+        "venueLocalStartTime": "2026-05-16T12:45:00",
+        "abbr": "ADEL V NMFC",
+        "thanksTicketLink": null,
+        "twitterHashTag": "#aflcrowsnorth"
+      },
+      "venue": {
+        "address": "Adelaide",
+        "name": "Adelaide Oval",
+        "state": "SA",
+        "timeZone": "Australia/Adelaide",
+        "venueId": "CD_V6",
+        "abbreviation": "AO",
+        "imageURL": null,
+        "capacity": null,
+        "groundDimension": null,
+        "latitude": null,
+        "longitude": null,
+        "ticketProviderLink": null,
+        "androidStadiumLink": null,
+        "iosStadiumLink": null,
+        "landOwner": "Kaurna"
+      },
+      "round": {
+        "name": "Round 10",
+        "year": "2026",
+        "roundId": "CD_R202601410",
+        "abbreviation": "Rd 10",
+        "competitionId": "CD_S2026014",
+        "roundNumber": 10
+      },
+      "liveVideos": [],
+      "score": {
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141004",
+        "homeTeamScore": {
+          "matchScore": {
+            "totalScore": 133,
+            "goals": 20,
+            "behinds": 13,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 26,
+                "goals": 4,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 64,
+                "goals": 10,
+                "behinds": 4,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 29,
+                "goals": 4,
+                "behinds": 5,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 14,
+                "goals": 2,
+                "behinds": 2,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 0,
+          "minutesInFront": 105
+        },
+        "awayTeamScore": {
+          "matchScore": {
+            "totalScore": 65,
+            "goals": 9,
+            "behinds": 11,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 22,
+                "goals": 3,
+                "behinds": 4,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 2,
+                "goals": 0,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 14,
+                "goals": 2,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 27,
+                "goals": 4,
+                "behinds": 3,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 1,
+          "minutesInFront": 19
+        },
+        "matchClock": {
+          "periods": [
+            {
+              "periodNumber": 1,
+              "periodSeconds": 1846,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 2,
+              "periodSeconds": 2000,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 3,
+              "periodSeconds": 1773,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 4,
+              "periodSeconds": 1937,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            }
+          ]
+        },
+        "weather": {
+          "description": "Showers easing",
+          "tempInCelsius": 21,
+          "weatherType": "RAIN"
+        },
+        "scoreWorm": null,
+        "scoreMap": null,
+        "homeTeamScoreChart": {
+          "goals": 20,
+          "leftBehinds": 5,
+          "rightBehinds": 5,
+          "leftPosters": 1,
+          "rightPosters": 2,
+          "rushedBehinds": 0,
+          "touchedBehinds": 0
+        },
+        "awayTeamScoreChart": {
+          "goals": 9,
+          "leftBehinds": 6,
+          "rightBehinds": 3,
+          "leftPosters": 0,
+          "rightPosters": 0,
+          "rushedBehinds": 1,
+          "touchedBehinds": 1
+        },
+        "lastUpdated": "2026-05-16T06:10:15.448+0000"
+      },
+      "k2kSponsored": false
+    },
+    {
+      "match": {
+        "name": "Narrm Vs Hawthorn",
+        "date": "2026-05-16T06:15:00.000+0000",
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141005",
+        "venue": "CD_V40",
+        "utcStartTime": "2026-05-16T06:15:00",
+        "homeTeamId": "CD_T90",
+        "awayTeamId": "CD_T80",
+        "homeTeam": {
+          "name": "Narrm",
+          "timeZone": null,
+          "teamId": "CD_T90",
+          "abbr": "MELB",
+          "nickname": "Demons",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_logos/400x400/melbourne_a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_flags/small/Melbourne.png"
+        },
+        "awayTeam": {
+          "name": "Hawthorn",
+          "timeZone": null,
+          "teamId": "CD_T80",
+          "abbr": "HAW",
+          "nickname": "Hawks",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_logos/400x400/hawthorn_a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_flags/small/Hawthorn.png"
+        },
+        "round": "CD_R202601410",
+        "venueLocalStartTime": "2026-05-16T16:15:00",
+        "abbr": "MELB V HAW",
+        "thanksTicketLink": null,
+        "twitterHashTag": "#afldeeshawks"
+      },
+      "venue": {
+        "address": "Melbourne",
+        "name": "MCG",
+        "state": "VIC",
+        "timeZone": "Australia/Melbourne",
+        "venueId": "CD_V40",
+        "abbreviation": "MCG",
+        "imageURL": null,
+        "capacity": null,
+        "groundDimension": null,
+        "latitude": null,
+        "longitude": null,
+        "ticketProviderLink": null,
+        "androidStadiumLink": null,
+        "iosStadiumLink": null,
+        "landOwner": "Wurundjeri"
+      },
+      "round": {
+        "name": "Round 10",
+        "year": "2026",
+        "roundId": "CD_R202601410",
+        "abbreviation": "Rd 10",
+        "competitionId": "CD_S2026014",
+        "roundNumber": 10
+      },
+      "liveVideos": [],
+      "score": {
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141005",
+        "homeTeamScore": {
+          "matchScore": {
+            "totalScore": 120,
+            "goals": 18,
+            "behinds": 12,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 21,
+                "goals": 3,
+                "behinds": 3,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 21,
+                "goals": 3,
+                "behinds": 3,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 38,
+                "goals": 6,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 40,
+                "goals": 6,
+                "behinds": 4,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 3,
+          "minutesInFront": 106
+        },
+        "awayTeamScore": {
+          "matchScore": {
+            "totalScore": 81,
+            "goals": 12,
+            "behinds": 9,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 21,
+                "goals": 3,
+                "behinds": 3,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 15,
+                "goals": 2,
+                "behinds": 3,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 24,
+                "goals": 4,
+                "behinds": 0,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 21,
+                "goals": 3,
+                "behinds": 3,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 3,
+          "minutesInFront": 7
+        },
+        "matchClock": {
+          "periods": [
+            {
+              "periodNumber": 1,
+              "periodSeconds": 1824,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 2,
+              "periodSeconds": 1843,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 3,
+              "periodSeconds": 1917,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 4,
+              "periodSeconds": 1855,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            }
+          ]
+        },
+        "weather": {
+          "description": "Possible late shower",
+          "tempInCelsius": 22,
+          "weatherType": "RAIN"
+        },
+        "scoreWorm": null,
+        "scoreMap": null,
+        "homeTeamScoreChart": {
+          "goals": 18,
+          "leftBehinds": 2,
+          "rightBehinds": 7,
+          "leftPosters": 0,
+          "rightPosters": 0,
+          "rushedBehinds": 3,
+          "touchedBehinds": 0
+        },
+        "awayTeamScoreChart": {
+          "goals": 12,
+          "leftBehinds": 2,
+          "rightBehinds": 3,
+          "leftPosters": 1,
+          "rightPosters": 0,
+          "rushedBehinds": 3,
+          "touchedBehinds": 0
+        },
+        "lastUpdated": "2026-05-16T09:00:40.560+0000"
+      },
+      "k2kSponsored": false
+    },
+    {
+      "match": {
+        "name": "Carlton Vs Western Bulldogs",
+        "date": "2026-05-16T09:35:00.000+0000",
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141006",
+        "venue": "CD_V190",
+        "utcStartTime": "2026-05-16T09:35:00",
+        "homeTeamId": "CD_T30",
+        "awayTeamId": "CD_T140",
+        "homeTeam": {
+          "name": "Carlton",
+          "timeZone": null,
+          "teamId": "CD_T30",
+          "abbr": "CARL",
+          "nickname": "Blues",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/Carlton-A.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/flag-carlton-sml.png"
+        },
+        "awayTeam": {
+          "name": "Western Bulldogs",
+          "timeZone": null,
+          "teamId": "CD_T140",
+          "abbr": "WB",
+          "nickname": "Bulldogs",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_logos/400x400/western_bulldogs_a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_flags/small/Western-Bulldogs.png"
+        },
+        "round": "CD_R202601410",
+        "venueLocalStartTime": "2026-05-16T19:35:00",
+        "abbr": "CARL V WB",
+        "thanksTicketLink": null,
+        "twitterHashTag": "#aflbluesdogs"
+      },
+      "venue": {
+        "address": "Melbourne",
+        "name": "Marvel Stadium",
+        "state": "VIC",
+        "timeZone": "Australia/Melbourne",
+        "venueId": "CD_V190",
+        "abbreviation": "MRVL",
+        "imageURL": null,
+        "capacity": null,
+        "groundDimension": null,
+        "latitude": null,
+        "longitude": null,
+        "ticketProviderLink": null,
+        "androidStadiumLink": null,
+        "iosStadiumLink": null,
+        "landOwner": "Wurundjeri"
+      },
+      "round": {
+        "name": "Round 10",
+        "year": "2026",
+        "roundId": "CD_R202601410",
+        "abbreviation": "Rd 10",
+        "competitionId": "CD_S2026014",
+        "roundNumber": 10
+      },
+      "liveVideos": [],
+      "score": {
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141006",
+        "homeTeamScore": {
+          "matchScore": {
+            "totalScore": 74,
+            "goals": 10,
+            "behinds": 14,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 17,
+                "goals": 2,
+                "behinds": 5,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 7,
+                "goals": 1,
+                "behinds": 1,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 17,
+                "goals": 2,
+                "behinds": 5,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 33,
+                "goals": 5,
+                "behinds": 3,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 4,
+          "minutesInFront": 32
+        },
+        "awayTeamScore": {
+          "matchScore": {
+            "totalScore": 62,
+            "goals": 9,
+            "behinds": 8,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 25,
+                "goals": 4,
+                "behinds": 1,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 9,
+                "goals": 1,
+                "behinds": 3,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 15,
+                "goals": 2,
+                "behinds": 3,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 13,
+                "goals": 2,
+                "behinds": 1,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 2,
+          "minutesInFront": 80
+        },
+        "matchClock": {
+          "periods": [
+            {
+              "periodNumber": 1,
+              "periodSeconds": 1733,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 2,
+              "periodSeconds": 1631,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 3,
+              "periodSeconds": 1703,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 4,
+              "periodSeconds": 2013,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            }
+          ]
+        },
+        "weather": {
+          "description": "Possible late shower",
+          "tempInCelsius": 22,
+          "weatherType": "RAIN"
+        },
+        "scoreWorm": null,
+        "scoreMap": null,
+        "homeTeamScoreChart": {
+          "goals": 10,
+          "leftBehinds": 3,
+          "rightBehinds": 3,
+          "leftPosters": 2,
+          "rightPosters": 0,
+          "rushedBehinds": 4,
+          "touchedBehinds": 2
+        },
+        "awayTeamScoreChart": {
+          "goals": 9,
+          "leftBehinds": 4,
+          "rightBehinds": 1,
+          "leftPosters": 1,
+          "rightPosters": 0,
+          "rushedBehinds": 2,
+          "touchedBehinds": 0
+        },
+        "lastUpdated": "2026-05-16T12:18:22.150+0000"
+      },
+      "k2kSponsored": false
+    },
+    {
+      "match": {
+        "name": "Essendon Vs Walyalup",
+        "date": "2026-05-17T03:10:00.000+0000",
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141007",
+        "venue": "CD_V40",
+        "utcStartTime": "2026-05-17T03:10:00",
+        "homeTeamId": "CD_T50",
+        "awayTeamId": "CD_T60",
+        "homeTeam": {
+          "name": "Essendon",
+          "timeZone": null,
+          "teamId": "CD_T50",
+          "abbr": "ESS",
+          "nickname": "Bombers",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_logos/400x400/essendon_a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_flags/small/Essendon.png"
+        },
+        "awayTeam": {
+          "name": "Walyalup",
+          "timeZone": null,
+          "teamId": "CD_T60",
+          "abbr": "FRE",
+          "nickname": "Freo",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_logos/400x400/fremantle_a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_flags/small/Fremantle.png"
+        },
+        "round": "CD_R202601410",
+        "venueLocalStartTime": "2026-05-17T13:10:00",
+        "abbr": "ESS V FRE",
+        "thanksTicketLink": null,
+        "twitterHashTag": "#afldonsfreo"
+      },
+      "venue": {
+        "address": "Melbourne",
+        "name": "MCG",
+        "state": "VIC",
+        "timeZone": "Australia/Melbourne",
+        "venueId": "CD_V40",
+        "abbreviation": "MCG",
+        "imageURL": null,
+        "capacity": null,
+        "groundDimension": null,
+        "latitude": null,
+        "longitude": null,
+        "ticketProviderLink": null,
+        "androidStadiumLink": null,
+        "iosStadiumLink": null,
+        "landOwner": "Wurundjeri"
+      },
+      "round": {
+        "name": "Round 10",
+        "year": "2026",
+        "roundId": "CD_R202601410",
+        "abbreviation": "Rd 10",
+        "competitionId": "CD_S2026014",
+        "roundNumber": 10
+      },
+      "liveVideos": [],
+      "score": {
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141007",
+        "homeTeamScore": {
+          "matchScore": {
+            "totalScore": 61,
+            "goals": 8,
+            "behinds": 13,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 9,
+                "goals": 1,
+                "behinds": 3,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 5,
+                "goals": 0,
+                "behinds": 5,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 16,
+                "goals": 2,
+                "behinds": 4,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 31,
+                "goals": 5,
+                "behinds": 1,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 4,
+          "minutesInFront": 0
+        },
+        "awayTeamScore": {
+          "matchScore": {
+            "totalScore": 104,
+            "goals": 16,
+            "behinds": 8,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 34,
+                "goals": 5,
+                "behinds": 4,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 32,
+                "goals": 5,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 18,
+                "goals": 3,
+                "behinds": 0,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 20,
+                "goals": 3,
+                "behinds": 2,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 2,
+          "minutesInFront": 116
+        },
+        "matchClock": {
+          "periods": [
+            {
+              "periodNumber": 1,
+              "periodSeconds": 1726,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 2,
+              "periodSeconds": 1698,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 3,
+              "periodSeconds": 1695,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 4,
+              "periodSeconds": 1919,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            }
+          ]
+        },
+        "weather": {
+          "description": "Rain",
+          "tempInCelsius": 17,
+          "weatherType": "RAIN"
+        },
+        "scoreWorm": null,
+        "scoreMap": null,
+        "homeTeamScoreChart": {
+          "goals": 8,
+          "leftBehinds": 5,
+          "rightBehinds": 3,
+          "leftPosters": 1,
+          "rightPosters": 0,
+          "rushedBehinds": 4,
+          "touchedBehinds": 0
+        },
+        "awayTeamScoreChart": {
+          "goals": 16,
+          "leftBehinds": 2,
+          "rightBehinds": 3,
+          "leftPosters": 1,
+          "rightPosters": 0,
+          "rushedBehinds": 2,
+          "touchedBehinds": 0
+        },
+        "lastUpdated": "2026-05-17T05:50:48.645+0000"
+      },
+      "k2kSponsored": false
+    },
+    {
+      "match": {
+        "name": "Euro-Yroke Vs Richmond",
+        "date": "2026-05-17T05:15:00.000+0000",
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141008",
+        "venue": "CD_V190",
+        "utcStartTime": "2026-05-17T05:15:00",
+        "homeTeamId": "CD_T130",
+        "awayTeamId": "CD_T120",
+        "homeTeam": {
+          "name": "Euro-Yroke",
+          "timeZone": null,
+          "teamId": "CD_T130",
+          "abbr": "STK",
+          "nickname": "Saints",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_logos/400x400/st_kilda_a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_flags/small/St-Kilda.png"
+        },
+        "awayTeam": {
+          "name": "Richmond",
+          "timeZone": null,
+          "teamId": "CD_T120",
+          "abbr": "RICH",
+          "nickname": "Tigers",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_logos/400x400/richmond_a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_flags/small/Richmond.png"
+        },
+        "round": "CD_R202601410",
+        "venueLocalStartTime": "2026-05-17T15:15:00",
+        "abbr": "STK V RICH",
+        "thanksTicketLink": null,
+        "twitterHashTag": "#aflsaintstigers"
+      },
+      "venue": {
+        "address": "Melbourne",
+        "name": "Marvel Stadium",
+        "state": "VIC",
+        "timeZone": "Australia/Melbourne",
+        "venueId": "CD_V190",
+        "abbreviation": "MRVL",
+        "imageURL": null,
+        "capacity": null,
+        "groundDimension": null,
+        "latitude": null,
+        "longitude": null,
+        "ticketProviderLink": null,
+        "androidStadiumLink": null,
+        "iosStadiumLink": null,
+        "landOwner": "Wurundjeri"
+      },
+      "round": {
+        "name": "Round 10",
+        "year": "2026",
+        "roundId": "CD_R202601410",
+        "abbreviation": "Rd 10",
+        "competitionId": "CD_S2026014",
+        "roundNumber": 10
+      },
+      "liveVideos": [],
+      "score": {
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141008",
+        "homeTeamScore": {
+          "matchScore": {
+            "totalScore": 109,
+            "goals": 16,
+            "behinds": 13,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 33,
+                "goals": 5,
+                "behinds": 3,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 32,
+                "goals": 5,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 22,
+                "goals": 3,
+                "behinds": 4,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 22,
+                "goals": 3,
+                "behinds": 4,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 2,
+          "minutesInFront": 121
+        },
+        "awayTeamScore": {
+          "matchScore": {
+            "totalScore": 73,
+            "goals": 11,
+            "behinds": 7,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 12,
+                "goals": 2,
+                "behinds": 0,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 27,
+                "goals": 4,
+                "behinds": 3,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 15,
+                "goals": 2,
+                "behinds": 3,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 19,
+                "goals": 3,
+                "behinds": 1,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 2,
+          "minutesInFront": 0
+        },
+        "matchClock": {
+          "periods": [
+            {
+              "periodNumber": 1,
+              "periodSeconds": 1871,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 2,
+              "periodSeconds": 1917,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 3,
+              "periodSeconds": 1753,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 4,
+              "periodSeconds": 1810,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            }
+          ]
+        },
+        "weather": {
+          "description": "Rain",
+          "tempInCelsius": 17,
+          "weatherType": "RAIN"
+        },
+        "scoreWorm": null,
+        "scoreMap": null,
+        "homeTeamScoreChart": {
+          "goals": 16,
+          "leftBehinds": 6,
+          "rightBehinds": 4,
+          "leftPosters": 0,
+          "rightPosters": 1,
+          "rushedBehinds": 2,
+          "touchedBehinds": 0
+        },
+        "awayTeamScoreChart": {
+          "goals": 11,
+          "leftBehinds": 1,
+          "rightBehinds": 3,
+          "leftPosters": 0,
+          "rightPosters": 1,
+          "rushedBehinds": 2,
+          "touchedBehinds": 0
+        },
+        "lastUpdated": "2026-05-17T08:03:35.825+0000"
+      },
+      "k2kSponsored": false
+    },
+    {
+      "match": {
+        "name": "Waalitj Marawar Vs GWS GIANTS",
+        "date": "2026-05-17T08:15:00.000+0000",
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141009",
+        "venue": "CD_V2925",
+        "utcStartTime": "2026-05-17T08:15:00",
+        "homeTeamId": "CD_T150",
+        "awayTeamId": "CD_T1010",
+        "homeTeam": {
+          "name": "Waalitj Marawar",
+          "timeZone": null,
+          "teamId": "CD_T150",
+          "abbr": "WCE",
+          "nickname": "Eagles",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_logos/400x400/west_coast_a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_flags/small/West-Coast.png"
+        },
+        "awayTeam": {
+          "name": "GWS GIANTS",
+          "timeZone": null,
+          "teamId": "CD_T1010",
+          "abbr": "GWS",
+          "nickname": "GIANTS",
+          "badgeAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_logos/400x400/gws_a.png",
+          "flagAssetURL": "https://s.afl.com.au/staticfile/AFL%20Tenant/AFLMobile/Static%20Files/team_flags/small/GWS.png"
+        },
+        "round": "CD_R202601410",
+        "venueLocalStartTime": "2026-05-17T16:15:00",
+        "abbr": "WCE V GWS",
+        "thanksTicketLink": null,
+        "twitterHashTag": "#afleaglesgiants"
+      },
+      "venue": {
+        "address": "Perth",
+        "name": "Optus Stadium",
+        "state": "WA",
+        "timeZone": "Australia/Perth",
+        "venueId": "CD_V2925",
+        "abbreviation": "OS",
+        "imageURL": null,
+        "capacity": null,
+        "groundDimension": null,
+        "latitude": null,
+        "longitude": null,
+        "ticketProviderLink": null,
+        "androidStadiumLink": null,
+        "iosStadiumLink": null,
+        "landOwner": "Whadjuk"
+      },
+      "round": {
+        "name": "Round 10",
+        "year": "2026",
+        "roundId": "CD_R202601410",
+        "abbreviation": "Rd 10",
+        "competitionId": "CD_S2026014",
+        "roundNumber": 10
+      },
+      "liveVideos": [],
+      "score": {
+        "status": "CONCLUDED",
+        "matchId": "CD_M20260141009",
+        "homeTeamScore": {
+          "matchScore": {
+            "totalScore": 88,
+            "goals": 13,
+            "behinds": 10,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 8,
+                "goals": 1,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 38,
+                "goals": 6,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 14,
+                "goals": 2,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 28,
+                "goals": 4,
+                "behinds": 4,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 2,
+          "minutesInFront": 50
+        },
+        "awayTeamScore": {
+          "matchScore": {
+            "totalScore": 71,
+            "goals": 10,
+            "behinds": 11,
+            "superGoals": null
+          },
+          "periodScore": [
+            {
+              "periodNumber": 1,
+              "score": {
+                "totalScore": 18,
+                "goals": 2,
+                "behinds": 6,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 2,
+              "score": {
+                "totalScore": 14,
+                "goals": 2,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 3,
+              "score": {
+                "totalScore": 32,
+                "goals": 5,
+                "behinds": 2,
+                "superGoals": null
+              }
+            },
+            {
+              "periodNumber": 4,
+              "score": {
+                "totalScore": 7,
+                "goals": 1,
+                "behinds": 1,
+                "superGoals": null
+              }
+            }
+          ],
+          "rushedBehinds": 2,
+          "minutesInFront": 75
+        },
+        "matchClock": {
+          "periods": [
+            {
+              "periodNumber": 1,
+              "periodSeconds": 1735,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 2,
+              "periodSeconds": 1946,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 3,
+              "periodSeconds": 2003,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            },
+            {
+              "periodNumber": 4,
+              "periodSeconds": 1982,
+              "periodCompleted": true,
+              "periodStart": null,
+              "nextPeriodStart": null
+            }
+          ]
+        },
+        "weather": {
+          "description": "Mostly sunny",
+          "tempInCelsius": 21,
+          "weatherType": "MOSTLY_SUNNY"
+        },
+        "scoreWorm": null,
+        "scoreMap": null,
+        "homeTeamScoreChart": {
+          "goals": 13,
+          "leftBehinds": 2,
+          "rightBehinds": 6,
+          "leftPosters": 0,
+          "rightPosters": 0,
+          "rushedBehinds": 2,
+          "touchedBehinds": 0
+        },
+        "awayTeamScoreChart": {
+          "goals": 10,
+          "leftBehinds": 2,
+          "rightBehinds": 5,
+          "leftPosters": 1,
+          "rightPosters": 0,
+          "rushedBehinds": 2,
+          "touchedBehinds": 1
+        },
+        "lastUpdated": "2026-05-17T11:19:19.783+0000"
+      },
+      "k2kSponsored": false
+    }
+  ]
+}

--- a/test/lib/team-mapping.test.ts
+++ b/test/lib/team-mapping.test.ts
@@ -145,4 +145,19 @@ describe("normaliseTeamName", () => {
     expect(normaliseTeamName("Port")).toBe("Port Adelaide");
     expect(normaliseTeamName("PAFC")).toBe("Port Adelaide");
   });
+
+  it("resolves Sir Doug Nicholls Round indigenous names to canonical clubs", () => {
+    expect(normaliseTeamName("Kuwarna")).toBe("Adelaide Crows");
+    expect(normaliseTeamName("Walyalup")).toBe("Fremantle");
+    expect(normaliseTeamName("Narrm")).toBe("Melbourne");
+    expect(normaliseTeamName("Yartapuulti")).toBe("Port Adelaide");
+    expect(normaliseTeamName("Euro-Yroke")).toBe("St Kilda");
+    expect(normaliseTeamName("Waalitj Marawar")).toBe("West Coast Eagles");
+  });
+
+  it("resolves indigenous names case-insensitively", () => {
+    expect(normaliseTeamName("walyalup")).toBe("Fremantle");
+    expect(normaliseTeamName("WAALITJ MARAWAR")).toBe("West Coast Eagles");
+    expect(normaliseTeamName("euro-yroke")).toBe("St Kilda");
+  });
 });

--- a/test/transforms/match-results.test.ts
+++ b/test/transforms/match-results.test.ts
@@ -1,5 +1,8 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import type { MatchItem } from "../../src/lib/validation";
+import { AFL_SENIOR_TEAMS } from "../../src/lib/team-mapping";
+import { type MatchItem, MatchItemListSchema } from "../../src/lib/validation";
 import { transformMatchItems } from "../../src/transforms/match-results";
 
 /** Minimal match item for testing. */
@@ -167,5 +170,33 @@ describe("transformMatchItems", () => {
 
   it("returns empty array for empty input", () => {
     expect(transformMatchItems([], 2025, "AFLM")).toEqual([]);
+  });
+});
+
+describe("transformMatchItems — Sir Doug Nicholls Round canonicalisation", () => {
+  const fixturePath = join(__dirname, "../fixtures/afl-api-round-10-2026.json");
+  const raw = JSON.parse(readFileSync(fixturePath, "utf-8"));
+  const response = MatchItemListSchema.parse(raw);
+
+  it("canonicalises indigenous team names returned by the AFL API during SDNR", () => {
+    const results = transformMatchItems(response.items, 2026, "AFLM");
+    expect(results).toHaveLength(9);
+
+    const teams = new Set<string>();
+    for (const m of results) {
+      teams.add(m.homeTeam);
+      teams.add(m.awayTeam);
+    }
+
+    for (const team of teams) {
+      expect(AFL_SENIOR_TEAMS.has(team), `unexpected non-canonical team: ${team}`).toBe(true);
+    }
+
+    expect(teams).toContain("Fremantle");
+    expect(teams).toContain("Adelaide Crows");
+    expect(teams).toContain("Melbourne");
+    expect(teams).toContain("Port Adelaide");
+    expect(teams).toContain("St Kilda");
+    expect(teams).toContain("West Coast Eagles");
   });
 });


### PR DESCRIPTION
## Summary

- Register the six indigenous team names returned by the AFL API during the Sir Doug Nicholls Round (`Kuwarna`, `Walyalup`, `Narrm`, `Yartapuulti`, `Euro-Yroke`, `Waalitj Marawar`) as additional aliases in `TEAM_ALIASES`. They are accepted as `--team` input on the CLI and as `MatchQuery.team` in the library, and they canonicalise automatically in `homeTeam`/`awayTeam` fields across all sources. Output is always the canonical club name.
- Empirically derived from R10/R11 of the 2026 AFLM season via the live AFL API; pinned by a transform-level test against a real round-10 fixture (`test/fixtures/afl-api-round-10-2026.json`).
- Bumps version to `2.2.0` (SemVer minor — additive change, no breaking modifications).

Related: jackemcpherson/AFL-MCP#78 (parallel changes needed in the MCP server's own `TEAM_NAME_MAP`).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run check` (Biome) — clean (4 pre-existing warnings in `fryzigg-player-stats.test.ts`, unrelated)
- [x] `npm run test` — 351/351 pass, including the new SDNR transform-level test
- [x] Live AFL API smoke: `node dist/cli.js match --season 2026 --round 10 --competition AFLM --source afl-api --json` returns only canonical names; no indigenous names leak through
- [x] Round-trip filter: `--team Walyalup` returns the Essendon vs Fremantle R10/2026 match

🤖 Generated with [Claude Code](https://claude.com/claude-code)