### PR TITLE
ci: use OIDC trusted publisher for npm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,13 @@ jobs:
     needs: [check]
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # `id-token: write` is required for OIDC trusted-publisher auth against npm.
+    # No static NPM_TOKEN is used — npm derives short-lived credentials from
+    # the workflow's OIDC identity, provided the package is configured with a
+    # GitHub trusted publisher pointing at this repo + workflow on npmjs.com.
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -79,10 +84,8 @@ jobs:
           if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version 2>/dev/null; then
             echo "Version ${PACKAGE_VERSION} already published — skipping"
           else
-            npm publish --access public
+            npm publish --provenance --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   build-binaries:
     needs: [check]


### PR DESCRIPTION
## Summary

- Replace static `NPM_TOKEN` secret with GitHub Actions OIDC + npm trusted publisher
- Add `--provenance` to `npm publish` so consumers get signed attestations linking each release to this exact repo/workflow/commit
- Eliminates the recurring "token expired" failure that has blocked every release since 2.0

## Required action before merging

Before this can publish, configure the GitHub trusted publisher for the `fitzroy` package on npmjs.com:

1. Visit https://www.npmjs.com/package/fitzroy/access
2. Settings → Publishing access → "Trusted Publisher" → Add
3. Repository: `jackemcpherson/fitzRoy-ts`
4. Workflow filename: `release.yml`
5. Environment: (leave blank)

After this PR merges, the existing `NPM_TOKEN` repository secret can be deleted from Settings → Secrets → Actions (kept for now to allow rollback).

## Test plan

- [ ] CI green on this PR
- [ ] Trusted publisher configured on npmjs.com
- [ ] After merge, dispatch the release workflow for v2.2.0 and confirm `publish-npm` succeeds
- [ ] Verify `npm view fitzroy@2.2.0` shows provenance metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)