### PR TITLE
ci: bump npm to 11.5.1+ in publish-npm job for OIDC auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,12 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
+      # npm trusted-publisher OIDC auth for `npm publish` requires npm 11.5.1+.
+      # Node 20 ships npm 10.x; provenance signing works on 10.x but the auth
+      # exchange against the registry returns 404 without 11.5.1+.
+      - name: Install npm 11.5.1+
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

OIDC trusted-publisher AUTH for \`npm publish\` requires npm 11.5.1+. Node 20 LTS ships npm 10.x, which signs provenance correctly but falls back to (empty) bearer-token auth and gets 404'd on the actual publish.

Adds \`npm install -g npm@latest\` before publish.

## Root cause trace

- v2.2.0 release attempts: both 404'd on \`PUT https://registry.npmjs.org/fitzroy\`
- Sigstore provenance attestations both succeeded (logIndex 1597784875, 1597812187)
- Trusted publisher correctly configured on npmjs.com (jackemcpherson/fitzRoy-ts, release.yml, npm publish permission)
- ⇒ OIDC token issued ✓, provenance signing path uses it ✓, but publish auth path doesn't because npm CLI is too old

## Test plan

- [ ] CI green on this PR
- [ ] After merge, dispatch release.yml for v2.2.0 and confirm publish-npm succeeds
- [ ] Verify \`npm view fitzroy@2.2.0\` shows version + provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)