### PR TITLE
P1: client timeouts, Squiggle status fix, opt-in 5xx retry, Fryzigg integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- All source clients now apply a default 30-second timeout to every
+  outbound request, and accept `signal` (combined with the timeout via
+  `AbortSignal.any`) and `timeoutMs` options. Previously a hung upstream
+  could block callers indefinitely.
+
+### Fixed
+
+- Squiggle: `fetchMatches({ source: "squiggle", status: "Upcoming" })`
+  (or `"Live"`) no longer silently returns `[]`. The adapter hardcoded
+  `complete=100`; it now applies the completion filter only for
+  `status: "Complete"` queries.
+
 ## [2.3.0] - 2026-06-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outbound request, and accept `signal` (combined with the timeout via
   `AbortSignal.any`) and `timeoutMs` options. Previously a hung upstream
   could block callers indefinitely.
+- Opt-in `retry5xx` client option: retries a request once (with jitter)
+  on a 5xx response, so a single transient 503 no longer aborts a
+  whole-season fetch.
 
 ### Fixed
 

--- a/src/lib/fetch-retry.ts
+++ b/src/lib/fetch-retry.ts
@@ -1,0 +1,37 @@
+/**
+ * Optional single-retry policy for transient upstream failures.
+ *
+ * A lone 503 from a scrape source previously aborted a whole-season
+ * fetch. Behind an opt-in flag, one jittered retry absorbs blips
+ * without hammering an upstream that is genuinely down.
+ */
+
+/** Options enabling a single jittered retry on HTTP 5xx responses. */
+export interface FetchRetryOptions {
+  /** Retry once (with 250–750 ms jitter) on 5xx responses. Off by default. */
+  readonly retry5xx?: boolean | undefined;
+}
+
+const RETRY_BASE_DELAY_MS = 250;
+const RETRY_JITTER_MS = 500;
+
+/**
+ * Wrap a fetch implementation with a single jittered retry on 5xx.
+ *
+ * Returns the original function untouched unless `retry5xx` is true.
+ * Network errors are not retried — only responses with a 5xx status.
+ */
+export function withRetry5xx(fetchFn: typeof fetch, options?: FetchRetryOptions): typeof fetch {
+  if (options?.retry5xx !== true) {
+    return fetchFn;
+  }
+  return async (input, init?) => {
+    const first = await fetchFn(input, init);
+    if (first.status < 500 || first.status > 599) {
+      return first;
+    }
+    const delay = RETRY_BASE_DELAY_MS + Math.random() * RETRY_JITTER_MS;
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    return fetchFn(input, init);
+  };
+}

--- a/src/lib/fetch-timeout.ts
+++ b/src/lib/fetch-timeout.ts
@@ -1,0 +1,50 @@
+/**
+ * Per-request timeout wrapping for source-client fetch functions.
+ *
+ * Every outbound request gets an AbortSignal so a hung upstream can
+ * never block a consumer indefinitely (a stalled FootyWire page or AFL
+ * token endpoint previously froze the whole Result chain — and every
+ * downstream consumer — forever).
+ */
+
+/** Default per-request timeout applied to every outbound fetch. */
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+
+/** Timeout/cancellation options shared by all source clients. */
+export interface FetchTimeoutOptions {
+  /**
+   * Caller-supplied signal combined with the per-request timeout, so
+   * callers can cancel all in-flight requests (e.g. on their own
+   * deadline) without disabling the default timeout.
+   */
+  readonly signal?: AbortSignal | undefined;
+  /** Per-request timeout in milliseconds. Defaults to 30 000. */
+  readonly timeoutMs?: number | undefined;
+}
+
+/**
+ * Wrap a fetch implementation so each call carries an abort signal.
+ *
+ * Precedence per request: an explicit `init.signal` wins untouched;
+ * otherwise the client-level signal (if any) is combined with a fresh
+ * `AbortSignal.timeout` for this request.
+ *
+ * @param fetchFn - The underlying fetch implementation.
+ * @param options - Client-level signal/timeout options.
+ * @returns A fetch-compatible function with timeout behaviour applied.
+ */
+export function withFetchTimeout(
+  fetchFn: typeof fetch,
+  options?: FetchTimeoutOptions,
+): typeof fetch {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const clientSignal = options?.signal;
+  return (input, init?) => {
+    if (init?.signal) {
+      return fetchFn(input, init);
+    }
+    const timeout = AbortSignal.timeout(timeoutMs);
+    const signal = clientSignal ? AbortSignal.any([clientSignal, timeout]) : timeout;
+    return fetchFn(input, { ...init, signal });
+  };
+}

--- a/src/lib/source-fetch.ts
+++ b/src/lib/source-fetch.ts
@@ -1,0 +1,22 @@
+/**
+ * The standard fetch pipeline shared by every source client.
+ */
+
+import { type FetchRetryOptions, withRetry5xx } from "./fetch-retry";
+import { type FetchTimeoutOptions, withFetchTimeout } from "./fetch-timeout";
+
+/** Common fetch-behaviour options accepted by every source client. */
+export interface SourceFetchOptions extends FetchTimeoutOptions, FetchRetryOptions {
+  /** Custom fetch implementation (defaults to global `fetch`). */
+  readonly fetchFn?: typeof fetch | undefined;
+}
+
+/**
+ * Compose the source-client fetch pipeline: per-request timeout
+ * innermost (so each retry attempt gets a fresh timeout), optional
+ * single jittered 5xx retry outermost.
+ */
+export function createSourceFetch(options?: SourceFetchOptions): typeof fetch {
+  const base = options?.fetchFn ?? globalThis.fetch.bind(globalThis);
+  return withRetry5xx(withFetchTimeout(base, options), options);
+}

--- a/src/sources/adapters/squiggle.ts
+++ b/src/sources/adapters/squiggle.ts
@@ -26,7 +26,12 @@ export class SquiggleMatchSource implements MatchSource {
   constructor(private readonly client: SquiggleClient = new SquiggleClient()) {}
 
   async fetchMatches(query: MatchQuery): Promise<Result<Match[], Error>> {
-    const result = await this.client.fetchGames(query.season, query.round ?? undefined, 100);
+    // Only constrain the API when the caller wants completed games:
+    // hardcoding complete=100 made Upcoming/Live queries silently return
+    // []. For other statuses fetch everything and let the API layer's
+    // filterMatches do the filtering.
+    const complete = query.status === "Complete" ? 100 : undefined;
+    const result = await this.client.fetchGames(query.season, query.round ?? undefined, complete);
     if (!result.success) return result;
     return ok(transformSquiggleGamesToFixture(result.data.games, query.season));
   }

--- a/src/sources/afl-api.ts
+++ b/src/sources/afl-api.ts
@@ -10,6 +10,7 @@
 import type { z } from "zod/v4";
 import { batchedMap } from "../lib/concurrency";
 import { AflApiError, ValidationError } from "../lib/errors";
+import { type FetchTimeoutOptions, withFetchTimeout } from "../lib/fetch-timeout";
 import { err, ok, type Result } from "../lib/result";
 import {
   AflApiTokenSchema,
@@ -76,7 +77,7 @@ interface CachedToken {
 }
 
 /** Options for constructing an {@link AflApiClient}. */
-export interface AflApiClientOptions {
+export interface AflApiClientOptions extends FetchTimeoutOptions {
   /** Custom fetch implementation (defaults to global `fetch`). */
   readonly fetchFn?: typeof fetch | undefined;
   /** Token endpoint override (useful for testing). */
@@ -100,7 +101,10 @@ export class AflApiClient {
   private pendingAuth: Promise<Result<string, AflApiError>> | null = null;
 
   constructor(options?: AflApiClientOptions) {
-    const baseFetch = options?.fetchFn ?? globalThis.fetch.bind(globalThis);
+    const baseFetch = withFetchTimeout(
+      options?.fetchFn ?? globalThis.fetch.bind(globalThis),
+      options,
+    );
     this.fetchFn = (input, init?) => {
       const headers = new Headers(init?.headers);
       if (!headers.has("User-Agent")) {

--- a/src/sources/afl-api.ts
+++ b/src/sources/afl-api.ts
@@ -10,8 +10,8 @@
 import type { z } from "zod/v4";
 import { batchedMap } from "../lib/concurrency";
 import { AflApiError, ValidationError } from "../lib/errors";
-import { type FetchTimeoutOptions, withFetchTimeout } from "../lib/fetch-timeout";
 import { err, ok, type Result } from "../lib/result";
+import { createSourceFetch, type SourceFetchOptions } from "../lib/source-fetch";
 import {
   AflApiTokenSchema,
   CompseasonListSchema,
@@ -77,7 +77,7 @@ interface CachedToken {
 }
 
 /** Options for constructing an {@link AflApiClient}. */
-export interface AflApiClientOptions extends FetchTimeoutOptions {
+export interface AflApiClientOptions extends SourceFetchOptions {
   /** Custom fetch implementation (defaults to global `fetch`). */
   readonly fetchFn?: typeof fetch | undefined;
   /** Token endpoint override (useful for testing). */
@@ -101,10 +101,7 @@ export class AflApiClient {
   private pendingAuth: Promise<Result<string, AflApiError>> | null = null;
 
   constructor(options?: AflApiClientOptions) {
-    const baseFetch = withFetchTimeout(
-      options?.fetchFn ?? globalThis.fetch.bind(globalThis),
-      options,
-    );
+    const baseFetch = createSourceFetch(options);
     this.fetchFn = (input, init?) => {
       const headers = new Headers(init?.headers);
       if (!headers.has("User-Agent")) {

--- a/src/sources/afl-coaches.ts
+++ b/src/sources/afl-coaches.ts
@@ -6,12 +6,13 @@
  */
 
 import { ScrapeError } from "../lib/errors";
+import { type FetchTimeoutOptions, withFetchTimeout } from "../lib/fetch-timeout";
 import { parseHtml } from "../lib/parse-html";
 import { err, ok, type Result } from "../lib/result";
 import type { CoachesVote, CompetitionCode } from "../types";
 
 /** Options for constructing an AFL Coaches client. */
-export interface AflCoachesClientOptions {
+export interface AflCoachesClientOptions extends FetchTimeoutOptions {
   readonly fetchFn?: typeof fetch | undefined;
 }
 
@@ -24,7 +25,7 @@ export class AflCoachesClient {
   private readonly fetchFn: typeof fetch;
 
   constructor(options?: AflCoachesClientOptions) {
-    this.fetchFn = options?.fetchFn ?? globalThis.fetch.bind(globalThis);
+    this.fetchFn = withFetchTimeout(options?.fetchFn ?? globalThis.fetch.bind(globalThis), options);
   }
 
   /**

--- a/src/sources/afl-coaches.ts
+++ b/src/sources/afl-coaches.ts
@@ -6,13 +6,13 @@
  */
 
 import { ScrapeError } from "../lib/errors";
-import { type FetchTimeoutOptions, withFetchTimeout } from "../lib/fetch-timeout";
 import { parseHtml } from "../lib/parse-html";
 import { err, ok, type Result } from "../lib/result";
+import { createSourceFetch, type SourceFetchOptions } from "../lib/source-fetch";
 import type { CoachesVote, CompetitionCode } from "../types";
 
 /** Options for constructing an AFL Coaches client. */
-export interface AflCoachesClientOptions extends FetchTimeoutOptions {
+export interface AflCoachesClientOptions extends SourceFetchOptions {
   readonly fetchFn?: typeof fetch | undefined;
 }
 
@@ -25,7 +25,7 @@ export class AflCoachesClient {
   private readonly fetchFn: typeof fetch;
 
   constructor(options?: AflCoachesClientOptions) {
-    this.fetchFn = withFetchTimeout(options?.fetchFn ?? globalThis.fetch.bind(globalThis), options);
+    this.fetchFn = createSourceFetch(options);
   }
 
   /**

--- a/src/sources/afl-tables.ts
+++ b/src/sources/afl-tables.ts
@@ -7,6 +7,7 @@
 
 import { localToUtc, parseDate } from "../lib/date-utils";
 import { ScrapeError } from "../lib/errors";
+import { type FetchTimeoutOptions, withFetchTimeout } from "../lib/fetch-timeout";
 import { parseHtml } from "../lib/parse-html";
 import { err, ok, type Result } from "../lib/result";
 import { normaliseTeamName } from "../lib/team-mapping";
@@ -28,7 +29,7 @@ import type {
 const AFL_TABLES_BASE = "https://afltables.com/afl/seas";
 
 /** Options for constructing an AFL Tables client. */
-export interface AflTablesClientOptions {
+export interface AflTablesClientOptions extends FetchTimeoutOptions {
   readonly fetchFn?: typeof fetch | undefined;
 }
 
@@ -39,7 +40,7 @@ export class AflTablesClient {
   private readonly fetchFn: typeof fetch;
 
   constructor(options?: AflTablesClientOptions) {
-    this.fetchFn = options?.fetchFn ?? globalThis.fetch.bind(globalThis);
+    this.fetchFn = withFetchTimeout(options?.fetchFn ?? globalThis.fetch.bind(globalThis), options);
   }
 
   /**

--- a/src/sources/afl-tables.ts
+++ b/src/sources/afl-tables.ts
@@ -5,11 +5,12 @@
  * back to 1897 for historical AFL/VFL results.
  */
 
+import { batchedMap } from "../lib/concurrency";
 import { localToUtc, parseDate } from "../lib/date-utils";
 import { ScrapeError } from "../lib/errors";
-import { type FetchTimeoutOptions, withFetchTimeout } from "../lib/fetch-timeout";
 import { parseHtml } from "../lib/parse-html";
 import { err, ok, type Result } from "../lib/result";
+import { createSourceFetch, type SourceFetchOptions } from "../lib/source-fetch";
 import { normaliseTeamName } from "../lib/team-mapping";
 import { emptyMetricSet } from "../lib/team-metrics";
 import { normaliseVenueName } from "../lib/venue-mapping";
@@ -29,7 +30,7 @@ import type {
 const AFL_TABLES_BASE = "https://afltables.com/afl/seas";
 
 /** Options for constructing an AFL Tables client. */
-export interface AflTablesClientOptions extends FetchTimeoutOptions {
+export interface AflTablesClientOptions extends SourceFetchOptions {
   readonly fetchFn?: typeof fetch | undefined;
 }
 
@@ -40,7 +41,7 @@ export class AflTablesClient {
   private readonly fetchFn: typeof fetch;
 
   constructor(options?: AflTablesClientOptions) {
-    this.fetchFn = withFetchTimeout(options?.fetchFn ?? globalThis.fetch.bind(globalThis), options);
+    this.fetchFn = createSourceFetch(options);
   }
 
   /**
@@ -107,43 +108,30 @@ export class AflTablesClient {
 
       const results = parseSeasonPage(seasonHtml, year);
 
-      const allStats: PlayerStats[] = [];
-      const batchSize = 5;
+      const indexedUrls = gameUrls.map((gameUrl, idx) => ({ gameUrl, idx }));
+      const perGameStats = await batchedMap(
+        indexedUrls,
+        async ({ gameUrl, idx }) => {
+          try {
+            const resp = await this.fetchFn(gameUrl, {
+              headers: { "User-Agent": "Mozilla/5.0" },
+            });
+            if (!resp.ok) return [];
 
-      for (let i = 0; i < gameUrls.length; i += batchSize) {
-        const batch = gameUrls.slice(i, i + batchSize);
-        const batchResults = await Promise.all(
-          batch.map(async (gameUrl, batchIdx) => {
-            try {
-              const resp = await this.fetchFn(gameUrl, {
-                headers: { "User-Agent": "Mozilla/5.0" },
-              });
-              if (!resp.ok) return [];
+            const html = await resp.text();
+            const urlMatch = /\/(\d+)\.html$/.exec(gameUrl);
+            const matchId = urlMatch?.[1] ?? `${year}_${idx}`;
+            const roundNumber = results[idx]?.roundNumber ?? 0;
 
-              const html = await resp.text();
-              const urlMatch = /\/(\d+)\.html$/.exec(gameUrl);
-              const matchId = urlMatch?.[1] ?? `${year}_${i + batchIdx}`;
-              const globalIdx = i + batchIdx;
-              const roundNumber = results[globalIdx]?.roundNumber ?? 0;
+            return parseAflTablesGameStats(html, matchId, year, roundNumber);
+          } catch {
+            return [];
+          }
+        },
+        { batchSize: 5, delayMs: 300 },
+      );
 
-              return parseAflTablesGameStats(html, matchId, year, roundNumber);
-            } catch {
-              return [];
-            }
-          }),
-        );
-
-        for (const stats of batchResults) {
-          allStats.push(...stats);
-        }
-
-        // Small delay between batches
-        if (i + batchSize < gameUrls.length) {
-          await new Promise((resolve) => setTimeout(resolve, 300));
-        }
-      }
-
-      return ok(allStats);
+      return ok(perGameStats.flat());
     } catch (cause) {
       return err(
         new ScrapeError(

--- a/src/sources/footywire.ts
+++ b/src/sources/footywire.ts
@@ -7,6 +7,7 @@
 
 import { parseDate } from "../lib/date-utils";
 import { ScrapeError } from "../lib/errors";
+import { type FetchTimeoutOptions, withFetchTimeout } from "../lib/fetch-timeout";
 import { parseHtml } from "../lib/parse-html";
 import { err, ok, type Result } from "../lib/result";
 import { normaliseTeamName } from "../lib/team-mapping";
@@ -31,7 +32,7 @@ import type {
 const FOOTYWIRE_BASE = "https://www.footywire.com/afl/footy";
 
 /** Options for constructing a FootyWire client. */
-export interface FootyWireClientOptions {
+export interface FootyWireClientOptions extends FetchTimeoutOptions {
   readonly fetchFn?: typeof fetch | undefined;
 }
 
@@ -42,7 +43,7 @@ export class FootyWireClient {
   private readonly fetchFn: typeof fetch;
 
   constructor(options?: FootyWireClientOptions) {
-    this.fetchFn = options?.fetchFn ?? globalThis.fetch.bind(globalThis);
+    this.fetchFn = withFetchTimeout(options?.fetchFn ?? globalThis.fetch.bind(globalThis), options);
   }
 
   /**

--- a/src/sources/footywire.ts
+++ b/src/sources/footywire.ts
@@ -7,9 +7,9 @@
 
 import { parseDate } from "../lib/date-utils";
 import { ScrapeError } from "../lib/errors";
-import { type FetchTimeoutOptions, withFetchTimeout } from "../lib/fetch-timeout";
 import { parseHtml } from "../lib/parse-html";
 import { err, ok, type Result } from "../lib/result";
+import { createSourceFetch, type SourceFetchOptions } from "../lib/source-fetch";
 import { normaliseTeamName } from "../lib/team-mapping";
 import { emptyMetricSet } from "../lib/team-metrics";
 import { normaliseVenueName } from "../lib/venue-mapping";
@@ -32,7 +32,7 @@ import type {
 const FOOTYWIRE_BASE = "https://www.footywire.com/afl/footy";
 
 /** Options for constructing a FootyWire client. */
-export interface FootyWireClientOptions extends FetchTimeoutOptions {
+export interface FootyWireClientOptions extends SourceFetchOptions {
   readonly fetchFn?: typeof fetch | undefined;
 }
 
@@ -43,7 +43,7 @@ export class FootyWireClient {
   private readonly fetchFn: typeof fetch;
 
   constructor(options?: FootyWireClientOptions) {
-    this.fetchFn = withFetchTimeout(options?.fetchFn ?? globalThis.fetch.bind(globalThis), options);
+    this.fetchFn = createSourceFetch(options);
   }
 
   /**

--- a/src/sources/fryzigg.ts
+++ b/src/sources/fryzigg.ts
@@ -22,6 +22,13 @@ import type { CompetitionCode } from "../types";
  * Fryzigg only publishes AFLM and AFLW datasets. VFL/VFLW are not available
  * from this source — the public API will return an UnsupportedSourceError
  * for those competitions in the source-adapter refactor (Phase B).
+ *
+ * Security note (SEC-10): fryziggafl.net does not serve HTTPS (verified
+ * 2026-06-10 — TLS connections are refused), so these downloads are
+ * plain HTTP and an on-path attacker could substitute content fed into
+ * the RDS parser. Mitigations: rds-js validates input defensively, and
+ * callers who mirror a known-good dataset can pin it via the
+ * `sha256` client option below.
  */
 const FRYZIGG_URLS: Partial<Record<CompetitionCode, string>> = {
   AFLM: "http://www.fryziggafl.net/static/fryziggafl.rds",
@@ -33,6 +40,12 @@ const USER_AGENT = "fitzRoy-ts/1.0 (https://github.com/jackemcpherson/fitzRoy-ts
 /** Options for constructing a Fryzigg client. */
 export interface FryziggClientOptions extends SourceFetchOptions {
   readonly fetchFn?: typeof fetch | undefined;
+  /**
+   * Optional hex-encoded SHA-256 checksum of the expected RDS payload.
+   * When set, a downloaded file that doesn't match is rejected — the
+   * only integrity control available while the host is HTTP-only.
+   */
+  readonly sha256?: string | undefined;
 }
 
 /**
@@ -45,9 +58,11 @@ export interface FryziggClientOptions extends SourceFetchOptions {
  */
 export class FryziggClient {
   private readonly fetchFn: typeof fetch;
+  private readonly sha256: string | undefined;
 
   constructor(options?: FryziggClientOptions) {
     this.fetchFn = createSourceFetch(options);
+    this.sha256 = options?.sha256;
   }
 
   /**
@@ -77,6 +92,22 @@ export class FryziggClient {
       }
 
       const buffer = new Uint8Array(await response.arrayBuffer());
+
+      if (this.sha256 !== undefined) {
+        const digest = await crypto.subtle.digest("SHA-256", buffer);
+        const actual = Array.from(new Uint8Array(digest))
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
+        if (actual !== this.sha256.toLowerCase()) {
+          return err(
+            new ScrapeError(
+              `Fryzigg checksum mismatch: expected ${this.sha256}, got ${actual}`,
+              "fryzigg",
+            ),
+          );
+        }
+      }
+
       const result = await parseRds(buffer);
 
       if (!isDataFrame(result)) {

--- a/src/sources/fryzigg.ts
+++ b/src/sources/fryzigg.ts
@@ -14,6 +14,7 @@
 import { type DataFrame, isDataFrame, parseRds, RdsError } from "@jackemcpherson/rds-js";
 
 import { ScrapeError } from "../lib/errors";
+import { type FetchTimeoutOptions, withFetchTimeout } from "../lib/fetch-timeout";
 import { err, ok, type Result } from "../lib/result";
 import type { CompetitionCode } from "../types";
 
@@ -30,7 +31,7 @@ const FRYZIGG_URLS: Partial<Record<CompetitionCode, string>> = {
 const USER_AGENT = "fitzRoy-ts/1.0 (https://github.com/jackemcpherson/fitzRoy-ts)";
 
 /** Options for constructing a Fryzigg client. */
-export interface FryziggClientOptions {
+export interface FryziggClientOptions extends FetchTimeoutOptions {
   readonly fetchFn?: typeof fetch | undefined;
 }
 
@@ -46,7 +47,7 @@ export class FryziggClient {
   private readonly fetchFn: typeof fetch;
 
   constructor(options?: FryziggClientOptions) {
-    this.fetchFn = options?.fetchFn ?? globalThis.fetch.bind(globalThis);
+    this.fetchFn = withFetchTimeout(options?.fetchFn ?? globalThis.fetch.bind(globalThis), options);
   }
 
   /**

--- a/src/sources/fryzigg.ts
+++ b/src/sources/fryzigg.ts
@@ -14,8 +14,8 @@
 import { type DataFrame, isDataFrame, parseRds, RdsError } from "@jackemcpherson/rds-js";
 
 import { ScrapeError } from "../lib/errors";
-import { type FetchTimeoutOptions, withFetchTimeout } from "../lib/fetch-timeout";
 import { err, ok, type Result } from "../lib/result";
+import { createSourceFetch, type SourceFetchOptions } from "../lib/source-fetch";
 import type { CompetitionCode } from "../types";
 
 /**
@@ -31,7 +31,7 @@ const FRYZIGG_URLS: Partial<Record<CompetitionCode, string>> = {
 const USER_AGENT = "fitzRoy-ts/1.0 (https://github.com/jackemcpherson/fitzRoy-ts)";
 
 /** Options for constructing a Fryzigg client. */
-export interface FryziggClientOptions extends FetchTimeoutOptions {
+export interface FryziggClientOptions extends SourceFetchOptions {
   readonly fetchFn?: typeof fetch | undefined;
 }
 
@@ -47,7 +47,7 @@ export class FryziggClient {
   private readonly fetchFn: typeof fetch;
 
   constructor(options?: FryziggClientOptions) {
-    this.fetchFn = withFetchTimeout(options?.fetchFn ?? globalThis.fetch.bind(globalThis), options);
+    this.fetchFn = createSourceFetch(options);
   }
 
   /**

--- a/src/sources/squiggle.ts
+++ b/src/sources/squiggle.ts
@@ -8,8 +8,8 @@
  */
 
 import { ScrapeError } from "../lib/errors";
-import { type FetchTimeoutOptions, withFetchTimeout } from "../lib/fetch-timeout";
 import { err, ok, type Result } from "../lib/result";
+import { createSourceFetch, type SourceFetchOptions } from "../lib/source-fetch";
 import {
   type SquiggleGamesResponse,
   SquiggleGamesResponseSchema,
@@ -21,7 +21,7 @@ const SQUIGGLE_BASE = "https://api.squiggle.com.au/";
 const USER_AGENT = "fitzRoy-ts/1.0 (https://github.com/jackemcpherson/fitzRoy-ts)";
 
 /** Options for constructing a Squiggle client. */
-export interface SquiggleClientOptions extends FetchTimeoutOptions {
+export interface SquiggleClientOptions extends SourceFetchOptions {
   readonly fetchFn?: typeof fetch | undefined;
 }
 
@@ -34,7 +34,7 @@ export class SquiggleClient {
   private readonly fetchFn: typeof fetch;
 
   constructor(options?: SquiggleClientOptions) {
-    this.fetchFn = withFetchTimeout(options?.fetchFn ?? globalThis.fetch.bind(globalThis), options);
+    this.fetchFn = createSourceFetch(options);
   }
 
   /**

--- a/src/sources/squiggle.ts
+++ b/src/sources/squiggle.ts
@@ -8,6 +8,7 @@
  */
 
 import { ScrapeError } from "../lib/errors";
+import { type FetchTimeoutOptions, withFetchTimeout } from "../lib/fetch-timeout";
 import { err, ok, type Result } from "../lib/result";
 import {
   type SquiggleGamesResponse,
@@ -20,7 +21,7 @@ const SQUIGGLE_BASE = "https://api.squiggle.com.au/";
 const USER_AGENT = "fitzRoy-ts/1.0 (https://github.com/jackemcpherson/fitzRoy-ts)";
 
 /** Options for constructing a Squiggle client. */
-export interface SquiggleClientOptions {
+export interface SquiggleClientOptions extends FetchTimeoutOptions {
   readonly fetchFn?: typeof fetch | undefined;
 }
 
@@ -33,7 +34,7 @@ export class SquiggleClient {
   private readonly fetchFn: typeof fetch;
 
   constructor(options?: SquiggleClientOptions) {
-    this.fetchFn = options?.fetchFn ?? globalThis.fetch.bind(globalThis);
+    this.fetchFn = withFetchTimeout(options?.fetchFn ?? globalThis.fetch.bind(globalThis), options);
   }
 
   /**

--- a/test/lib/fetch-retry.test.ts
+++ b/test/lib/fetch-retry.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { withRetry5xx } from "../../src/lib/fetch-retry";
+
+describe("withRetry5xx", () => {
+  it("is a no-op unless enabled", async () => {
+    const inner = vi.fn(
+      async () => new Response("down", { status: 503 }),
+    ) as unknown as typeof fetch;
+    const wrapped = withRetry5xx(inner);
+    const res = await wrapped("https://example.com/");
+    expect(res.status).toBe(503);
+    expect(inner).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries exactly once on 5xx when enabled", async () => {
+    const inner = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("down", { status: 503 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 })) as unknown as typeof fetch;
+    const wrapped = withRetry5xx(inner, { retry5xx: true });
+    const res = await wrapped("https://example.com/");
+    expect(res.status).toBe(200);
+    expect(inner).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the second response even if it also fails", async () => {
+    const inner = vi.fn(
+      async () => new Response("down", { status: 502 }),
+    ) as unknown as typeof fetch;
+    const wrapped = withRetry5xx(inner, { retry5xx: true });
+    const res = await wrapped("https://example.com/");
+    expect(res.status).toBe(502);
+    expect(inner).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry 4xx responses", async () => {
+    const inner = vi.fn(
+      async () => new Response("nope", { status: 404 }),
+    ) as unknown as typeof fetch;
+    const wrapped = withRetry5xx(inner, { retry5xx: true });
+    const res = await wrapped("https://example.com/");
+    expect(res.status).toBe(404);
+    expect(inner).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/lib/fetch-timeout.test.ts
+++ b/test/lib/fetch-timeout.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { withFetchTimeout } from "../../src/lib/fetch-timeout";
+
+function abortAwareFetch(): typeof fetch {
+  return ((_input: RequestInfo | URL, init?: RequestInit) =>
+    new Promise((resolve, reject) => {
+      if (!init?.signal) {
+        resolve(new Response("no signal"));
+        return;
+      }
+      init.signal.addEventListener("abort", () => reject(init.signal?.reason));
+    })) as typeof fetch;
+}
+
+describe("withFetchTimeout", () => {
+  it("attaches an abort signal to every request by default", async () => {
+    const seen: Array<RequestInit | undefined> = [];
+    const inner = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen.push(init);
+      return new Response("ok");
+    }) as unknown as typeof fetch;
+
+    const wrapped = withFetchTimeout(inner);
+    await wrapped("https://example.com/");
+    expect(seen[0]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("aborts a hung request once the timeout elapses", async () => {
+    const wrapped = withFetchTimeout(abortAwareFetch(), { timeoutMs: 20 });
+    await expect(wrapped("https://example.com/")).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+  });
+
+  it("leaves an explicit per-request init.signal untouched", async () => {
+    const seen: Array<RequestInit | undefined> = [];
+    const inner = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen.push(init);
+      return new Response("ok");
+    }) as unknown as typeof fetch;
+
+    const controller = new AbortController();
+    const wrapped = withFetchTimeout(inner, { timeoutMs: 20 });
+    await wrapped("https://example.com/", { signal: controller.signal });
+    expect(seen[0]?.signal).toBe(controller.signal);
+  });
+
+  it("combines a client-level signal with the timeout", async () => {
+    const controller = new AbortController();
+    const wrapped = withFetchTimeout(abortAwareFetch(), {
+      signal: controller.signal,
+      timeoutMs: 10_000,
+    });
+    const pending = wrapped("https://example.com/");
+    controller.abort(new Error("caller cancelled"));
+    await expect(pending).rejects.toMatchObject({ message: "caller cancelled" });
+  });
+});

--- a/test/sources/adapters/squiggle.test.ts
+++ b/test/sources/adapters/squiggle.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { SquiggleMatchSource } from "../../../src/sources/adapters/squiggle";
+import type { SquiggleClient } from "../../../src/sources/squiggle";
+
+function clientSpy() {
+  const fetchGames = vi.fn(async () => ({
+    success: true as const,
+    data: { games: [] },
+  }));
+  return { fetchGames, client: { fetchGames } as unknown as SquiggleClient };
+}
+
+describe("SquiggleMatchSource status handling (COR-02)", () => {
+  it("omits the complete filter for Upcoming queries so fixtures can return", async () => {
+    const { fetchGames, client } = clientSpy();
+    const source = new SquiggleMatchSource(client);
+
+    const result = await source.fetchMatches({
+      source: "squiggle",
+      season: 2026,
+      status: "Upcoming",
+    });
+
+    expect(result.success).toBe(true);
+    expect(fetchGames).toHaveBeenCalledWith(2026, undefined, undefined);
+  });
+
+  it("omits the complete filter when no status is requested", async () => {
+    const { fetchGames, client } = clientSpy();
+    const source = new SquiggleMatchSource(client);
+
+    await source.fetchMatches({ source: "squiggle", season: 2026 });
+    expect(fetchGames).toHaveBeenCalledWith(2026, undefined, undefined);
+  });
+
+  it("passes complete=100 only for Complete queries", async () => {
+    const { fetchGames, client } = clientSpy();
+    const source = new SquiggleMatchSource(client);
+
+    await source.fetchMatches({ source: "squiggle", season: 2026, status: "Complete" });
+    expect(fetchGames).toHaveBeenCalledWith(2026, undefined, 100);
+  });
+});


### PR DESCRIPTION
## Summary
- **OPT-01**: every source client now applies a default 30s `AbortSignal.timeout` per request; `signal` (combined via `AbortSignal.any`) and `timeoutMs` exposed in all client options — a hung upstream can no longer block consumers indefinitely
- **COR-02**: Squiggle adapter no longer hardcodes `complete=100`, so `status: "Upcoming"/"Live"` queries return matches instead of silently returning `[]`
- **OPT-04**: opt-in `retry5xx` (one jittered retry on 5xx) via a shared `createSourceFetch` pipeline; AFL Tables' hand-rolled 300ms pacing migrated to `batchedMap`
- **SEC-10**: Fryzigg host refuses TLS (verified), so the HTTP risk is documented and an optional `sha256` pin verifies the payload before parsing

All non-breaking; CHANGELOG updated under [Unreleased] for a future v2.x release.

## Test plan
- [x] 363 tests green (+11 new), typecheck + biome at baseline
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)