### PR TITLE
ci: reuse ci.yml via workflow_call; tag-version guard; standard dependabot (MNT-05, MNT-06)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,21 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+      interval: weekly
     open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,35 +15,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: "1.3"
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Typecheck
-        run: npm run typecheck
-
-      - name: Lint and format
-        run: npm run check
-
-      - name: Test
-        run: npm run test
-
-      - name: Build
-        run: bun run build
-
-      - name: Verify package contents
-        run: npm pack --dry-run
-
-      - name: Check type exports
-        run: bunx attw --pack . --ignore-rules cjs-resolves-to-esm
+    uses: ./.github/workflows/ci.yml
 
   publish-npm:
     needs: [check]
@@ -82,6 +54,16 @@ jobs:
 
       - name: Verify package contents
         run: npm pack --dry-run
+
+      - name: Verify tag matches package.json version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag v$TAG_VERSION does not match package.json version $PKG_VERSION" >&2
+            exit 1
+          fi
 
       - name: Publish to npm
         run: |


### PR DESCRIPTION
The release workflow duplicated the full CI check list, so the two
could drift. release.yml now calls the reusable ci.yml (AFL-MCP's
fleet pattern), publish asserts the tag matches package.json (the
pre-2.0 release review caught exactly this drift once), and
dependabot.yml is standardised on the fleet config.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
