### PR TITLE
fitzroy v3.0.0: API trim, schemas subpath, bundled CLI, partial-result envelopes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
         run: npm pack --dry-run
 
       - name: Check type exports
-        run: bunx attw --pack . --ignore-rules cjs-resolves-to-esm
+        run: bunx attw --pack . --profile esm-only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Typecheck (portable core, no Node types)
+        run: npm run typecheck:portable
+
       - name: Lint and format
         run: npm run check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Test
         run: npm run test
 
+      # Informational only — no thresholds are configured, so coverage
+      # never fails the build (TST-06).
+      - name: Coverage summary
+        run: npm run test:coverage
+
       - name: Build
         run: bun run build
 

--- a/.github/workflows/scraper-canary.yml
+++ b/.github/workflows/scraper-canary.yml
@@ -1,0 +1,45 @@
+# Weekly liveness probe for the scraper sources (TST-03). Deliberately a
+# separate workflow from ci.yml so a flaky upstream can never block CI.
+# On failure it opens (or comments on) a "Scraper canary failure" issue.
+name: Scraper canary
+
+on:
+  schedule:
+    - cron: "0 20 * * 1" # Mondays 20:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run canary
+        run: bun scripts/canary.ts
+
+      - name: Open or update tracking issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          title="Scraper canary failure"
+          body="The weekly scraper canary failed on $(date -u +%Y-%m-%dT%H:%M:%SZ). See the run log: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          existing=$(gh issue list --state open --search "\"$title\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -38,9 +38,7 @@ coverage/
 # development artifacts
 plans/
 AGENTS.md
-CONTEXT.md
 HANDOFF.md
-docs/adr/
 
 # comparison test outputs (keep scripts, ignore generated data)
 comparison/*.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `fetchPlayerStats` now returns a `SeasonPlayerStats`
+  partial-result envelope (`{ stats, failedMatchIds }`) instead of a bare
+  `PlayerStats[]`. Season scrapes (afl-tables, footywire) used to silently
+  drop games whose page fetch failed — a season missing 30 games still
+  looked like a complete success. Failed games are now listed in
+  `failedMatchIds` (same namespace as `PlayerStats.matchId`) while the
+  rest of the season is returned in `stats`. Total failure of the season
+  page itself is still an `err` Result, and the CLI `stats` command prints
+  a stderr warning when games are missing. Migrate by reading
+  `result.data.stats` where you previously read `result.data`.
+
 ### Added
 
 - All source clients now apply a default 30-second timeout to every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   page itself is still an `err` Result, and the CLI `stats` command prints
   a stderr warning when games are missing. Migrate by reading
   `result.data.stats` where you previously read `result.data`.
+- **BREAKING**: FootyWire match-list rows no longer fabricate
+  goals/behinds from total points (`floor(points / 6)` produced
+  plausible-but-wrong data indistinguishable from real values
+  downstream). `homeGoals`/`homeBehinds`/`awayGoals`/`awayBehinds` are
+  now `null` for `source: "footywire"` matches — only
+  `homePoints`/`awayPoints` are real on that page.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- AFL Tables: season player-stats round numbers are now looked up by the
+  game's AFL Tables id instead of array index, so one skipped season-page
+  row no longer shifts every later game's round number.
+- AFL Tables: the fallback date for unparseable date text is now midnight
+  UTC on 1 January instead of local-machine-timezone midnight.
+- AFL API: season resolution anchors the year with word boundaries, so a
+  year embedded in a longer number in a compseason name can no longer be
+  matched by mistake.
 - Squiggle: `fetchMatches({ source: "squiggle", status: "Upcoming" })`
   (or `"Live"`) no longer silently returns `[]`. The adapter hardcoded
   `complete=100`; it now applies the completion filter only for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING**: the package root now exports only the supported surface
+  (fetch functions, domain types, errors, `Result`, source clients, and
+  date/name utilities). Raw AFL API and Squiggle wire schemas moved to
+  the new `fitzroy/schemas` subpath export so upstream drift no longer
+  forces a major release; internal transform functions are no longer
+  exported.
+
+### Removed
+
+- **BREAKING**: deprecated date-parsing aliases (`parseAflApiDate`,
+  `parseAflApiMatchTime`, `parseAflTablesDate`, `parseFootyWireDate`) —
+  use `parseDate`. The deprecated `SquadPlayer` type alias — use
+  `Player`.
+
+### Changed
+
 - **BREAKING**: `fetchPlayerStats` now returns a `SeasonPlayerStats`
   partial-result envelope (`{ stats, failedMatchIds }`) instead of a bare
   `PlayerStats[]`. Season scrapes (afl-tables, footywire) used to silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-06-11
+
 ### Changed
 
 - **BREAKING**: the package root now exports only the supported surface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   forces a major release; internal transform functions are no longer
   exported.
 
+- **BREAKING for CLI-from-source users only**: `citty`, `@clack/prompts`
+  and `picocolors` are now devDependencies bundled into the published
+  `dist/cli.js`, so library consumers no longer install interactive CLI
+  dependencies. `npx fitzroy` / the binary releases are unaffected.
+- `@jackemcpherson/rds-js` bumped to ^0.3.0 (hardened parser).
+
 ### Removed
 
 - **BREAKING**: deprecated date-parsing aliases (`parseAflApiDate`,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,124 @@
+# CONTEXT
+
+Domain vocabulary and architectural concepts for fitzRoy-ts. Read this before
+proposing structural changes.
+
+## Competitions
+
+| Code   | Name                              | Coverage requirement |
+|--------|-----------------------------------|----------------------|
+| `AFLM` | AFL Men's Premiership             | from 1990 (start of AFL era) |
+| `AFLW` | AFL Women's Premiership           | from 2017 (full history) |
+| `VFL`  | VFL / AFL Reserves men's          | from 2021 (modern AFL Reserves era) |
+| `VFLW` | VFLW women's reserves             | from 2021 |
+
+Out of scope: pre-1990 AFLM (VFL era), pre-2021 VFL/VFLW, state leagues
+(SANFL, WAFL), talent leagues (U18), AFL preseason/Origin/Indigenous All Stars
+(separate competitions in the AFL API).
+
+## User-facing commands (six)
+
+Every command shares one UX idiom: **drill in by adding flags** from a uniform
+vocabulary (`-s/--season`, `-r/--round`, `--team`, `--source`, `--competition`).
+Operation-specific filters extend the set per command.
+
+| Command   | Concept                                                          |
+|-----------|------------------------------------------------------------------|
+| `team`    | identity with temporal zoom: `team` → entity; `team -s` → squad; `team -s -r` → lineup |
+| `player`  | biographical lookup; `player NAME [-s S]` → bio + optional season summary |
+| `match`   | matches in any temporal scope; `--status` filter subsumes "fixture" |
+| `stats`   | performance numbers; `--by player` (default) or `--by team`       |
+| `ladder`  | standings                                                         |
+| `awards`  | season recognitions; `--type {brownlow,coleman,coaches,all-australian,rising-star}` |
+
+## Canonical domain types
+
+- **Match** — unified type for matches in any state. A "fixture" is a Match
+  with `status="Upcoming"` and null score fields. There is no separate Fixture
+  type.
+- **Squad** — team's roster for a season. Biographical fields (DOB, height,
+  draft, debut). Subsumes any per-source "player list" notion.
+- **Lineup** — match-day team sheet. Positional fields (jumper, position,
+  isEmergency, isSubstitute). Distinct from Squad.
+- **PlayerStats** — per-player per-match performance numbers.
+- **Award** — season recognition. Either *fetched* (Brownlow, Coaches votes,
+  All-Australian, Rising Star) or *computed* (Coleman, etc.). The `awards`
+  subsystem hides this distinction behind one verb.
+
+## Architectural concepts
+
+### Source-adapter pattern with capability descriptors
+
+Each source implements only the per-capability interfaces it satisfies
+(`MatchSource`, `PlayerStatsSource`, `SquadSource`, `LadderSource`, etc.) and
+declares an inline coverage map:
+
+```ts
+readonly coverage: ReadonlyMap<CompetitionCode, { minSeason: number; maxSeason?: number }>;
+```
+
+Public API functions are 3-line registry lookups: find the adapter for the
+requested source, check coverage, delegate. All per-source quirks (auth,
+URL building, response parsing) live in the adapter, not the api layer.
+
+**Implementation:** `src/sources/adapters/` holds:
+
+- `capabilities.ts` — the per-capability interfaces
+- `coverage.ts` — `SeasonRange`, `CoverageMap`, `checkCoverage` helper, structured errors
+- `registry.ts` — per-capability `Map<DataSource, Adapter>`s with register/get/list helpers
+- `{afl-api, footywire, afl-tables, squiggle, fryzigg}.ts` — one file per source, with one class per capability the source satisfies (e.g. `AflApiMatchSource`, `AflApiPlayerStatsSource`, `AflApiSquadSource`, `AflApiLineupSource`, `AflApiLadderSource`)
+- `index.ts` — bootstrap that instantiates each adapter, registers it, and re-exports the public surface
+
+Per-capability classes (rather than one fat per-source class) exist because
+coverage genuinely varies per operation: AFL Tables matches go back to 1897,
+but its player stats only start ~1965; AFL Tables ladder is *computed* from
+match results, so it inherits match coverage. Each capability class declares
+its own `coverage` map.
+
+### No silent cross-source fallback
+
+If a request falls outside the chosen source's coverage, the public API
+returns a structured error suggesting an alternative `--source`. Sources are
+never silently swapped — see ADR-0001.
+
+### Awards is concept-first, not source-first
+
+`fetchAwards` dispatches on `award` type to either fetch (Brownlow from
+FootyWire, Coaches from afl-coaches.com) or compute (Coleman = sum goals
+across PlayerStats). Source heterogeneity is hidden from the caller. This
+is the deepest module in the codebase: small interface, substantial behaviour.
+
+### CLI consolidates, library stays factored
+
+For `team` (and `stats`), the user-facing CLI command is one verb that
+dispatches to multiple library functions based on flag presence. Library
+keeps precise types (Squad and Lineup have orthogonal field sets that don't
+collapse cleanly into one type). The CLI dispatcher handles the consolidation.
+
+## Source coverage (as of 2026-05)
+
+| Source        | AFLM                             | AFLW           | VFL    | VFLW   |
+|---------------|----------------------------------|----------------|--------|--------|
+| afl-api (default) | 2012+                        | 2017+          | 2021+  | 2021+  |
+| afl-tables    | 1897+ results, ~1965+ stats      | —              | —      | —      |
+| footywire     | ~2010+                           | —              | —      | —      |
+| squiggle      | 2012+                            | —              | —      | —      |
+| fryzigg       | varies                           | varies         | —      | —      |
+| afl-coaches   | 2006+ (votes)                    | 2018+ (votes)  | —      | —      |
+
+Notes:
+- AFL API has no `team-stats` endpoint — `fetchTeamStats` falls back to
+  `afl-tables` (or `footywire`), which means it requires `--source` for any
+  request the default can't serve.
+- AFL API VFL/VFLW PlayerStats are partial: 20/30 core fields populated; the
+  10 advanced fields (bounces, totalPossessions, marksInside50, onePercenters,
+  clangers, goalAssists, goalAccuracy, turnovers, shotsAtGoal, metresGained)
+  are null. These are already nullable in the type, so no schema change.
+- AFL API competition resolution uses a hardcoded `(CompetitionCode → competitionId)`
+  map — the `code` field in `/competitions` is ambiguous (four entries share
+  `code="AFL"`).
+
+## Probe scripts
+
+`scripts/probe-afl-api.ts` and `scripts/probe-afl-tables.ts` verify source
+coverage. Run periodically to confirm assumptions in this document still hold.

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
   "files": {
-    "includes": ["**", "!!**/.wrangler", "!!**/dist", "!!**/test/fixtures"]
+    "includes": ["**", "!!**/.wrangler", "!!**/dist", "!!**/test/fixtures", "!!**/coverage"]
   },
   "linter": {
     "enabled": true,

--- a/build.ts
+++ b/build.ts
@@ -21,13 +21,16 @@ await build({
   platform: "neutral",
 });
 
-// CLI bundle — external deps, node platform for process/fs access
+// CLI bundle — node platform for process/fs access. The interactive
+// CLI-only deps (citty, @clack/prompts, picocolors) are devDependencies
+// bundled INTO dist/cli.js so library consumers never install them;
+// the library's runtime deps stay external and resolve from node_modules.
 await build({
   entryPoints: ["src/cli.ts"],
   bundle: true,
   format: "esm",
   outfile: "dist/cli.js",
-  packages: "external",
+  external: Object.keys(pkg.dependencies),
   platform: "node",
   define: {
     PACKAGE_VERSION: JSON.stringify(pkg.version),

--- a/build.ts
+++ b/build.ts
@@ -11,6 +11,16 @@ await build({
   platform: "neutral",
 });
 
+// Schemas subpath bundle — raw upstream wire schemas (fitzroy/schemas)
+await build({
+  entryPoints: ["src/schemas.ts"],
+  bundle: true,
+  format: "esm",
+  outfile: "dist/schemas.js",
+  packages: "external",
+  platform: "neutral",
+});
+
 // CLI bundle — external deps, node platform for process/fs access
 await build({
   entryPoints: ["src/cli.ts"],

--- a/bun.lock
+++ b/bun.lock
@@ -5,22 +5,22 @@
     "": {
       "name": "fitzroy-ts",
       "dependencies": {
-        "@clack/prompts": "^1.1.0",
-        "@jackemcpherson/rds-js": "0.2.0",
+        "@jackemcpherson/rds-js": "^0.3.0",
         "cheerio": "^1.0.0",
-        "citty": "^0.2.1",
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
-        "picocolors": "^1.1.1",
         "zod": "^4.3.6",
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",
         "@biomejs/biome": "^2.4.9",
+        "@clack/prompts": "^1.1.0",
         "@types/node": "^25.5.0",
         "@vitest/coverage-v8": "^4.1.1",
         "bunup": "^0.16.31",
+        "citty": "^0.2.1",
         "esbuild": "^0.27.4",
+        "picocolors": "^1.1.1",
         "typescript": "^6.0.2",
         "vitest": "^4.1.1",
       },
@@ -134,7 +134,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
 
-    "@jackemcpherson/rds-js": ["@jackemcpherson/rds-js@0.2.0", "", {}, "sha512-YMaai5MFEM+KwfkhetiQR5Q/mJUzJu7HntjSj++3hG8hVcpSUgsAcd0Q3TVSvCiT2lOM3Qf6MmYarfmiWDoMgQ=="],
+    "@jackemcpherson/rds-js": ["@jackemcpherson/rds-js@0.3.0", "", {}, "sha512-d9ThVCDgvPMP6n9JC+UI7g2NtnhM/kQS/N61XCJeOyeLpllFjR6jBgdgq36S5n3NEjP4q3p26+UrAfroOhRxwQ=="],
 
     "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "@arethetypeswrong/cli": "^0.18.2",
         "@biomejs/biome": "^2.4.9",
         "@types/node": "^25.5.0",
+        "@vitest/coverage-v8": "^4.1.1",
         "bunup": "^0.16.31",
         "esbuild": "^0.27.4",
         "typescript": "^6.0.2",
@@ -39,9 +40,11 @@
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
-    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.4.9", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.9", "@biomejs/cli-darwin-x64": "2.4.9", "@biomejs/cli-linux-arm64": "2.4.9", "@biomejs/cli-linux-arm64-musl": "2.4.9", "@biomejs/cli-linux-x64": "2.4.9", "@biomejs/cli-linux-x64-musl": "2.4.9", "@biomejs/cli-win32-arm64": "2.4.9", "@biomejs/cli-win32-x64": "2.4.9" }, "bin": { "biome": "bin/biome" } }, "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA=="],
 
@@ -133,7 +136,11 @@
 
     "@jackemcpherson/rds-js": ["@jackemcpherson/rds-js@0.2.0", "", {}, "sha512-YMaai5MFEM+KwfkhetiQR5Q/mJUzJu7HntjSj++3hG8hVcpSUgsAcd0Q3TVSvCiT2lOM3Qf6MmYarfmiWDoMgQ=="],
 
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@loaderkit/resolve": ["@loaderkit/resolve@1.0.6", "", { "dependencies": { "@braidai/lang": "^1.0.0" } }, "sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg=="],
 
@@ -287,6 +294,8 @@
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.8", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.8", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.8", "vitest": "4.1.8" }, "optionalPeers": ["@vitest/browser"] }, "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw=="],
+
     "@vitest/expect": ["@vitest/expect@4.1.1", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.1", "@vitest/utils": "4.1.1", "chai": "^6.2.2", "tinyrainbow": "^3.0.3" } }, "sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.1.1", "", { "dependencies": { "@vitest/spy": "4.1.1", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A=="],
@@ -299,7 +308,7 @@
 
     "@vitest/spy": ["@vitest/spy@4.1.1", "", {}, "sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.1", "", { "dependencies": { "@vitest/pretty-format": "4.1.1", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.0.3" } }, "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ=="],
+    "@vitest/utils": ["@vitest/utils@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
@@ -310,6 +319,8 @@
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.4", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
@@ -395,11 +406,21 @@
 
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -428,6 +449,10 @@
     "lru-cache": ["lru-cache@11.5.0", "", {}, "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.3", "", { "dependencies": { "@babel/parser": "^7.29.3", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "marked": ["marked@9.1.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q=="],
 
@@ -553,7 +578,19 @@
 
     "@arethetypeswrong/core/typescript": ["typescript@5.6.1-rc", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ=="],
 
+    "@babel/parser/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@bunup/dts/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
     "@bunup/dts/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "@vitest/expect/@vitest/utils": ["@vitest/utils@4.1.1", "", { "dependencies": { "@vitest/pretty-format": "4.1.1", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.0.3" } }, "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ=="],
+
+    "@vitest/runner/@vitest/utils": ["@vitest/utils@4.1.1", "", { "dependencies": { "@vitest/pretty-format": "4.1.1", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.0.3" } }, "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ=="],
+
+    "@vitest/snapshot/@vitest/utils": ["@vitest/utils@4.1.1", "", { "dependencies": { "@vitest/pretty-format": "4.1.1", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.0.3" } }, "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ=="],
+
+    "@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@4.1.8", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA=="],
 
     "cli-highlight/parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
 
@@ -566,6 +603,12 @@
     "marked-terminal/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "vitest/@vitest/utils": ["@vitest/utils@4.1.1", "", { "dependencies": { "@vitest/pretty-format": "4.1.1", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.0.3" } }, "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ=="],
+
+    "@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "cli-highlight/parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
   }

--- a/bunup.config.ts
+++ b/bunup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "bunup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/schemas.ts"],
   dtsOnly: true,
   dts: {
     inferTypes: true,

--- a/docs/adr/0001-no-cross-source-fallback.md
+++ b/docs/adr/0001-no-cross-source-fallback.md
@@ -1,0 +1,67 @@
+# ADR-0001: No silent cross-source fallback
+
+**Status:** Accepted
+**Date:** 2026-05-06
+
+## Context
+
+fitzRoy-ts queries multiple AFL data sources (AFL API, AFL Tables, FootyWire,
+Squiggle, Fryzigg, AFL Coaches). Each source covers a different subset of
+competitions and seasons (see CONTEXT.md, "Source coverage").
+
+A natural design instinct, when designing the unified `--source` UX, is to
+silently fall back to a different source when the chosen source can't serve
+the request. For example: AFL API only has AFLM data from 2012; if a user
+asks for AFLM 2005, the system *could* automatically route to AFL Tables
+(which has data back to 1897) and return data without complaint.
+
+This was considered and rejected during architecture review (May 2026).
+
+## Decision
+
+**The public API never silently routes to a different source.** When a
+request falls outside the chosen source's coverage, the API returns a
+structured error suggesting an alternative `--source` value.
+
+```
+Error: AFL API only covers AFLM from 2012.
+Try `--source afl-tables` for earlier seasons.
+```
+
+## Why
+
+Three reasons, in order of importance:
+
+1. **Field shapes differ subtly between sources.** AFL API returns rich stats
+   (kicks, marks, advanced metrics like ratingPoints, extendedStats);
+   AFL Tables returns the classic stat lines but lacks the advanced fields;
+   FootyWire returns yet another shape. A user comparing 2010 (afl-tables
+   fallback) against 2015 (afl-api) would silently get incomparable data.
+   The nullable fields would mask which source was used.
+
+2. **Provenance matters for downstream analysis.** Users of fitzRoy-ts often
+   build pipelines that join, average, or model this data. They need to know
+   *which* source produced *which* row. Silent routing destroys that
+   information unless we add a per-row source field — at which point we've
+   reinvented the explicit `--source` choice without the user-facing clarity.
+
+3. **Failure becomes feedback.** An explicit "try `--source afl-tables`" error
+   teaches users which source covers what. Silent fallback hides the
+   architecture.
+
+## Consequences
+
+- Users querying outside default coverage see an error, not data.
+- The error message must be helpful — it must name the alternative source.
+- The capability descriptors on each adapter (Phase B) need to be accurate
+  enough that the suggestion in the error is correct.
+- We accept that some requests have no answer (e.g., AFLW 2005 doesn't exist
+  on any source — and AFLW didn't exist as a competition), and the error in
+  those cases just states "no source covers this request."
+
+## Will be re-suggested
+
+Yes. Future architecture reviews will look at the user experience and propose
+"why don't we auto-route?" This is a reasonable instinct that needs an
+explicit answer. This ADR is that answer. Don't reopen unless one of the
+three reasons above no longer holds.

--- a/docs/adr/0002-pre-2021-vfl-out-of-scope.md
+++ b/docs/adr/0002-pre-2021-vfl-out-of-scope.md
@@ -1,0 +1,78 @@
+# ADR-0002: Pre-2021 VFL/VFLW out of scope
+
+**Status:** Accepted
+**Date:** 2026-05-06
+
+## Context
+
+When AFLW (2017+) and VFL/VFLW (modern AFL Reserves, 2021+) were added to
+scope for the 2.0 release, the question arose: how far back should each
+competition be supported?
+
+The hard requirements settled in design review:
+- AFLM from **1990** (start of the AFL era)
+- AFLW from **2017** (full history; AFLW didn't exist before then)
+- VFL/VFLW "**ideally**" with comparable historical depth
+
+The "ideally" was investigated by probing available sources.
+
+## Decision
+
+**Pre-2021 VFL and VFLW data is out of scope for the 2.0 release.**
+
+VFL and VFLW are supported from 2021+ via the AFL API (which began tracking
+the modern AFL Reserves competition that year). Earlier seasons return a
+clear "no source covers this request" error.
+
+## What we found
+
+Three sources were checked for pre-2021 VFL coverage:
+
+1. **AFL Tables** (`afltables.com`): probed at multiple URL patterns
+   (`/vfl/seas/`, `/vfl/`, `/afl/vfl/`, etc.) — every URL returns 404.
+   AFL Tables is AFLM-only; it has never hosted VFL data.
+
+2. **vflstats.com.au**: this is the source the R `fitzRoy` package's
+   `fetch_team_stats(source = "vflstats")` points at. The domain returned DNS
+   errors on every variant (`vflstats.com`, `vflstats.com.au`,
+   `www.vflstats.com`, `www.vflstats.com.au`). The site appears to be dead.
+
+3. **AFL API**: confirmed only goes back to 2021 for VFL (compId=7) and
+   VFLW (compId=11).
+
+The probe is at `scripts/probe-afl-tables.ts` and can be re-run if any
+source's status changes.
+
+## Why deferred, not done
+
+Adding pre-2021 VFL would require finding and scraping a new source. Likely
+candidates (the VFL website itself, archived state-league sites, third-party
+historical databases) are each non-trivial scraping engagements with
+unknown data quality. None of this work is reusable across other
+competitions; it's purely VFL-specific.
+
+The 2.0 release already delivers significant scope: AFLW and VFL/VFLW (2021+)
+become first-class, the public API consolidates into six commands, and the
+source-adapter architecture lands. Adding another scraping vertical for
+historical VFL would meaningfully delay 2.0 without being requested by
+existing users.
+
+## Consequences
+
+- VFL and VFLW queries with `season < 2021` return an out-of-range error.
+- Users who genuinely need pre-2021 VFL data will have to source it
+  themselves (or open an issue requesting we investigate further).
+- If a usable source for historical VFL is found later, it can be added as
+  an additional adapter without breaking changes — the source-adapter
+  pattern accommodates new adapters cleanly.
+
+## Will be re-suggested
+
+Yes. The asymmetry — AFLM history back to 1897, VFL only back to 2021 — is
+visible enough that future contributors will propose closing the gap. Don't
+reopen unless one of the following changes:
+
+- A reliable source for pre-2021 VFL data is found, OR
+- A user files a concrete request explaining their need, OR
+- An ADR-0001 reversal makes silent multi-source routing acceptable (it
+  isn't, see ADR-0001).

--- a/docs/adr/0003-adapter-loops-intentionally-not-unified.md
+++ b/docs/adr/0003-adapter-loops-intentionally-not-unified.md
@@ -1,0 +1,93 @@
+# ADR-0003: Adapter PlayerStats batching loops are intentionally not unified
+
+**Status:** Accepted
+**Date:** 2026-05-06
+
+## Context
+
+The three `PlayerStatsSource` adapters — `AflApiPlayerStatsSource`,
+`FootyWirePlayerStatsSource`, `AflTablesPlayerStatsSource` — each implement a
+similar-shaped loop:
+
+1. Resolve match IDs for a season (or filtered to a round).
+2. Batch-fetch per-match stats.
+3. Concatenate into a single `PlayerStats[]`.
+
+Surface similarity makes this look like obvious duplication. A natural
+refactor instinct is to extract a shared higher-order helper that takes
+"id resolver" + "per-id transform" + "batching options" as primitives, with
+each adapter providing only its source-specific bits.
+
+This was considered during architecture review (May 2026) and rejected.
+
+## Decision
+
+**The three loops stay separate.** Each adapter owns its full pipeline. The
+only shared primitive is `batchedMap` (in `src/lib/concurrency.ts`), which
+exposes a `delayMs` option for politeness delays in scraper sources.
+
+## Why
+
+The loops differ on five orthogonal axes — and three of those differences
+are deliberate product choices, not implementation accidents.
+
+1. **`matchId` fast-path.** AFL API can fetch stats for a single match
+   directly via `/cfs/afl/playerStats/{matchId}` and is the only adapter
+   that exposes this fast-path. The other two have to walk the full
+   round/season list. A unified helper would either lose the fast-path or
+   require a "skip the resolver step" branch that defeats the abstraction.
+
+2. **Roster / `teamIdMap` pre-fetch.** The AFL API path needs an extra
+   roster fetch to map the API's opaque team IDs to canonical team names
+   before the per-match transform runs. The scrapers already get team
+   names in their stats payload. The pre-fetch is single-source.
+
+3. **Politeness delay between batches.** FootyWire and AFL Tables sleep
+   500ms between batches to be respectful to the scraped sites. AFL API is
+   a real API and doesn't need it. (Captured by the `delayMs` option on
+   `batchedMap`, which IS shared.)
+
+4. **Error semantics — fail-fast vs best-effort.** The AFL API adapter
+   returns the first error it sees (`return statsResult ?? err(...)`) —
+   any failure is a bug, surface it. The scrapers silently skip failed
+   matches and continue (`if (result.success) allStats.push(...)`) —
+   scrapers fail often (404s on missing match pages, transient HTML
+   changes), and best-effort is the right product choice. A unified
+   helper would have to expose this as a parameter, at which point the
+   caller still has to think about it.
+
+5. **Per-match transform context.** AFL API's `transformPlayerStats`
+   takes a rich context object (`matchId`, `season`, `roundNumber`,
+   `competition`, `teamIdMap`, `date`, `homeTeam`, `awayTeam`). The
+   scrapers' stats are already shaped at the source layer and need
+   nothing extra. Threading a "per-source context" type through a generic
+   helper is more code than the duplication it removes.
+
+## What we did instead
+
+Extracted the one piece that genuinely is shared: the politeness delay.
+`batchedMap` now accepts an optional `delayMs` option, and
+`FootyWirePlayerStatsSource` uses it instead of its hand-rolled batching
+loop. ~5-line net change.
+
+## Consequences
+
+- The three adapter `fetchPlayerStats` methods stay roughly 30–80 lines
+  each. They look similar and they are — but the differences are
+  load-bearing.
+- New `PlayerStatsSource` adapters (e.g. a future Squiggle or Fryzigg
+  player-stats path) should write their own loop, copying the closest
+  existing adapter as a starting point. Don't try to subclass or
+  parameterise off an existing one.
+- If a fourth adapter lands and its loop is genuinely identical to one
+  of the existing three (same fast-path, same error semantics, same
+  transform context), reopen this ADR — at four, the case for extraction
+  is stronger.
+
+## Will be re-suggested
+
+Yes. The visual similarity of the three loops is striking enough that
+future architecture reviews will propose extraction. This ADR is the
+answer. Don't reopen unless one of the five axes above collapses (e.g.
+all sources adopt the same error semantics, or roster pre-fetch
+disappears) — or a fourth adapter lands with an identical-shape loop.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "scripts": {
     "build": "bunup && bun run build.ts",
     "test": "vitest",
+    "test:coverage": "vitest run --coverage",
     "check": "biome check .",
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit",
@@ -57,6 +58,7 @@
     "@arethetypeswrong/cli": "^0.18.2",
     "@biomejs/biome": "^2.4.9",
     "@types/node": "^25.5.0",
+    "@vitest/coverage-v8": "^4.1.1",
     "bunup": "^0.16.31",
     "esbuild": "^0.27.4",
     "typescript": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fitzroy",
   "version": "2.3.0",
-  "description": "TypeScript port of the fitzRoy R package — programmatic access to AFL data including match results, player stats, fixtures, ladders, and more",
+  "description": "TypeScript port of the fitzRoy R package \u2014 programmatic access to AFL data including match results, player stats, fixtures, ladders, and more",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./schemas": {
+      "types": "./dist/schemas.d.ts",
+      "import": "./dist/schemas.js"
     }
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "check": "biome check .",
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit",
+    "typecheck:portable": "tsc --noEmit -p tsconfig.portable.json",
     "prepublishOnly": "bun run build",
     "prerelease": "npm run typecheck && npm run check && npm run test && bun run build"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fitzroy",
-  "version": "2.3.0",
-  "description": "TypeScript port of the fitzRoy R package \u2014 programmatic access to AFL data including match results, player stats, fixtures, ladders, and more",
+  "version": "3.0.0",
+  "description": "TypeScript port of the fitzRoy R package — programmatic access to AFL data including match results, player stats, fixtures, ladders, and more",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -49,22 +49,22 @@
     "prerelease": "npm run typecheck && npm run check && npm run test && bun run build"
   },
   "dependencies": {
-    "@clack/prompts": "^1.1.0",
-    "@jackemcpherson/rds-js": "0.2.0",
+    "@jackemcpherson/rds-js": "^0.3.0",
     "cheerio": "^1.0.0",
-    "citty": "^0.2.1",
     "parse5": "^7.3.0",
     "parse5-htmlparser2-tree-adapter": "^7.1.0",
-    "picocolors": "^1.1.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",
     "@biomejs/biome": "^2.4.9",
+    "@clack/prompts": "^1.1.0",
     "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^4.1.1",
     "bunup": "^0.16.31",
+    "citty": "^0.2.1",
     "esbuild": "^0.27.4",
+    "picocolors": "^1.1.1",
     "typescript": "^6.0.2",
     "vitest": "^4.1.1"
   },

--- a/scripts/canary.ts
+++ b/scripts/canary.ts
@@ -1,0 +1,82 @@
+/**
+ * Scraper canary (TST-03) — hits ONE cheap live page/endpoint per data
+ * source and asserts the parsers still return non-empty Results for the
+ * previous season. Run weekly by `.github/workflows/scraper-canary.yml`
+ * (and on demand via `bun scripts/canary.ts`).
+ *
+ * Notes:
+ * - Each client keeps its default 30-second timeout — no overrides here.
+ * - Fryzigg is intentionally skipped: its only artefact is an ~11 MB RDS
+ *   dump, which is too heavy for a weekly liveness probe.
+ * - Exits non-zero when any check fails so the workflow can open (or
+ *   comment on) a tracking issue.
+ */
+
+import { AflApiClient } from "../src/sources/afl-api";
+import { AflTablesClient } from "../src/sources/afl-tables";
+import { FootyWireClient } from "../src/sources/footywire";
+import { SquiggleClient } from "../src/sources/squiggle";
+
+/** Previous season — guaranteed to have complete published data. */
+const season = new Date().getUTCFullYear() - 1;
+
+interface CanaryCheck {
+  readonly name: string;
+  /** Runs the probe; resolves to a one-line summary or throws on failure. */
+  readonly run: () => Promise<string>;
+}
+
+const checks: readonly CanaryCheck[] = [
+  {
+    // Public no-auth endpoint exercising the CompseasonListSchema parse.
+    name: "afl-api",
+    run: async () => {
+      const result = await new AflApiClient().resolveCompSeason("AFLM", season);
+      if (!result.success) throw result.error;
+      return `resolved AFLM ${season} to compseason id ${result.data}`;
+    },
+  },
+  {
+    name: "afl-tables",
+    run: async () => {
+      const result = await new AflTablesClient().fetchSeasonResults(season);
+      if (!result.success) throw result.error;
+      if (result.data.length === 0) throw new Error(`parsed 0 matches for ${season}`);
+      return `parsed ${result.data.length} matches for ${season}`;
+    },
+  },
+  {
+    name: "footywire",
+    run: async () => {
+      const result = await new FootyWireClient().fetchSeasonResults(season);
+      if (!result.success) throw result.error;
+      if (result.data.length === 0) throw new Error(`parsed 0 matches for ${season}`);
+      return `parsed ${result.data.length} matches for ${season}`;
+    },
+  },
+  {
+    name: "squiggle",
+    run: async () => {
+      const result = await new SquiggleClient().fetchGames(season, 1);
+      if (!result.success) throw result.error;
+      if (result.data.games.length === 0) throw new Error(`parsed 0 games for ${season} round 1`);
+      return `parsed ${result.data.games.length} games for ${season} round 1`;
+    },
+  },
+];
+
+let hasFailure = false;
+for (const check of checks) {
+  try {
+    const summary = await check.run();
+    console.log(`ok   ${check.name}: ${summary}`);
+  } catch (error) {
+    hasFailure = true;
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`FAIL ${check.name}: ${message}`);
+  }
+}
+
+if (hasFailure) {
+  process.exitCode = 1;
+}

--- a/src/api/awards.ts
+++ b/src/api/awards.ts
@@ -217,8 +217,8 @@ async function fetchColemanLeaderboard(query: AwardQuery): Promise<Result<Award[
     season: query.season,
     competition,
   });
-  return Result.map(statsR, (stats) =>
-    rankColemanFromStats(stats, query.season, competition, query.limit),
+  return Result.map(statsR, (seasonStats) =>
+    rankColemanFromStats(seasonStats.stats, query.season, competition, query.limit),
   );
 }
 

--- a/src/api/player-stats.ts
+++ b/src/api/player-stats.ts
@@ -7,21 +7,34 @@
 
 import { Result } from "../lib/result";
 import { dispatch, playerStatsRegistry } from "../sources/adapters/index";
-import type { PlayerStats, PlayerStatsQuery } from "../types";
+import type { PlayerStatsQuery, SeasonPlayerStats } from "../types";
 
 /**
  * Fetch per-player match statistics.
  *
+ * Returns a {@link SeasonPlayerStats} partial-result envelope. Season
+ * scrapes (afl-tables, footywire) fetch one page per game; games that
+ * fail are listed in `failedMatchIds` instead of silently vanishing,
+ * while the rest of the season still comes back in `stats`. Sources
+ * without per-game fetches and single-match (`matchId`) queries always
+ * return an empty `failedMatchIds`.
+ *
  * @example
  * ```ts
- * await fetchPlayerStats({
+ * const result = await fetchPlayerStats({
  *   source: "afl-api", season: 2025, round: 1, competition: "AFLM"
  * });
+ * if (result.success) {
+ *   console.log(result.data.stats.length, "stat lines");
+ *   if (result.data.failedMatchIds.length > 0) {
+ *     console.warn("missing games:", result.data.failedMatchIds);
+ *   }
+ * }
  * ```
  */
 export async function fetchPlayerStats(
   query: PlayerStatsQuery,
-): Promise<Result<PlayerStats[], Error>> {
+): Promise<Result<SeasonPlayerStats, Error>> {
   const adapterR = dispatch(playerStatsRegistry, "player stats", query);
   return Result.flatMapAsync(adapterR, (a) => a.fetchPlayerStats(query));
 }

--- a/src/cli/commands/stats.ts
+++ b/src/cli/commands/stats.ts
@@ -7,6 +7,7 @@
  */
 
 import { defineCommand } from "citty";
+import pc from "picocolors";
 import { fetchPlayerStats, fetchTeamStats } from "../../index";
 import { fuzzySearch } from "../../lib/fuzzy";
 import { playerStatsRegistry, teamStatsRegistry } from "../../sources/adapters/registry";
@@ -146,7 +147,19 @@ export const statsCommand = defineCommand({
     );
     if (!result.success) throw result.error;
 
-    let data = result.data;
+    // Season scrapes can lose individual games — warn (on stderr, so JSON/CSV
+    // stdout output stays clean) rather than silently presenting a partial
+    // season as complete.
+    const { failedMatchIds } = result.data;
+    if (failedMatchIds.length > 0) {
+      console.error(
+        pc.yellow(
+          `Warning: ${failedMatchIds.length} game(s) failed to fetch and are missing from the results: ${failedMatchIds.join(", ")}`,
+        ),
+      );
+    }
+
+    let data = result.data.stats;
     // Sources other than afl-api ignore matchId at the adapter layer (#123).
     // When --match resolved to a known game, post-filter to its participants
     // so cross-source behaviour matches afl-api's per-match scoping.

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,7 @@ export type {
   QuarterScore,
   RisingStarNomination,
   RoundType,
+  SeasonPlayerStats,
   SeasonRoundQuery,
   Squad,
   SquadPlayer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,12 @@
  * fitzRoy-ts — TypeScript port of the {@link https://github.com/jimmyday12/fitzRoy | fitzRoy R package}
  * for programmatic access to AFL (Australian Football League) data.
  *
+ * v3 trimmed this entry point to the supported surface: the `fetch*`
+ * functions, the domain model, errors, the Result type, source clients
+ * (for fetch/timeout injection), and a handful of date/name utilities.
+ * Raw upstream wire schemas live in the `fitzroy/schemas` subpath;
+ * internal transforms are no longer exported.
+ *
  * @packageDocumentation
  */
 
@@ -16,11 +22,7 @@ export { fetchSquad, fetchTeams } from "./api/teams";
 export {
   localToUtc,
   type ParseDateOptions,
-  parseAflApiDate,
-  parseAflApiMatchTime,
-  parseAflTablesDate,
   parseDate,
-  parseFootyWireDate,
   resolveDefaultSeason,
   toAestString,
 } from "./lib/date-utils";
@@ -33,78 +35,11 @@ export {
   UnsupportedSourceError,
   ValidationError,
 } from "./lib/errors";
+export type { FetchRetryOptions } from "./lib/fetch-retry";
+export type { FetchTimeoutOptions } from "./lib/fetch-timeout";
 export { type Err, err, type Ok, ok, Result } from "./lib/result";
-export {
-  type SquiggleGame,
-  SquiggleGameSchema,
-  type SquiggleGamesResponse,
-  SquiggleGamesResponseSchema,
-  type SquiggleStanding,
-  SquiggleStandingSchema,
-  type SquiggleStandingsResponse,
-  SquiggleStandingsResponseSchema,
-} from "./lib/squiggle-validation";
+export type { SourceFetchOptions } from "./lib/source-fetch";
 export { normaliseTeamName } from "./lib/team-mapping";
-export {
-  type AflApiToken,
-  AflApiTokenSchema,
-  type CfsMatch,
-  CfsMatchSchema,
-  type CfsMatchTeam,
-  CfsMatchTeamSchema,
-  type CfsScore,
-  CfsScoreSchema,
-  type CfsVenue,
-  CfsVenueSchema,
-  type Competition,
-  type CompetitionList,
-  CompetitionListSchema,
-  CompetitionSchema,
-  type Compseason,
-  type CompseasonList,
-  CompseasonListSchema,
-  CompseasonSchema,
-  type LadderEntryRaw,
-  LadderEntryRawSchema,
-  type LadderResponse,
-  LadderResponseSchema,
-  type MatchItem,
-  type MatchItemList,
-  MatchItemListSchema,
-  MatchItemSchema,
-  type MatchRoster,
-  MatchRosterSchema,
-  type PeriodScore,
-  PeriodScoreSchema,
-  type PlayerGameStats,
-  PlayerGameStatsSchema,
-  type PlayerStatsItem,
-  PlayerStatsItemSchema,
-  type PlayerStatsList,
-  PlayerStatsListSchema,
-  type RosterPlayer,
-  RosterPlayerSchema,
-  type Round,
-  type RoundList,
-  RoundListSchema,
-  RoundSchema,
-  type Score,
-  ScoreSchema,
-  type SquadList,
-  SquadListSchema,
-  SquadPlayerInnerSchema,
-  type SquadPlayerItem,
-  SquadPlayerItemSchema,
-  SquadSchema,
-  type TeamItem,
-  TeamItemSchema,
-  type TeamList,
-  TeamListSchema,
-  type TeamPlayers,
-  TeamPlayersSchema,
-  type TeamScore,
-  TeamScoreSchema,
-} from "./lib/validation";
 export { normaliseVenueName } from "./lib/venue-mapping";
 export { resolveVenueTimezone } from "./lib/venue-timezones";
 export { AflApiClient, type AflApiClientOptions } from "./sources/afl-api";
@@ -113,20 +48,6 @@ export { AflTablesClient, type AflTablesClientOptions } from "./sources/afl-tabl
 export { FootyWireClient, type FootyWireClientOptions } from "./sources/footywire";
 export { FryziggClient, type FryziggClientOptions } from "./sources/fryzigg";
 export { SquiggleClient, type SquiggleClientOptions } from "./sources/squiggle";
-export { computeLadder } from "./transforms/computed-ladder";
-export {
-  type FryziggTransformOptions,
-  transformFryziggPlayerStats,
-} from "./transforms/fryzigg-player-stats";
-export { transformLadderEntries } from "./transforms/ladder";
-export { transformMatchRoster } from "./transforms/lineup";
-export { inferRoundType, transformMatchItems } from "./transforms/match-results";
-export { type TransformContext, transformPlayerStats } from "./transforms/player-stats";
-export {
-  transformSquiggleGamesToFixture,
-  transformSquiggleGamesToResults,
-  transformSquiggleStandings,
-} from "./transforms/squiggle";
 export type {
   AllAustralianSelection,
   Award,
@@ -158,7 +79,6 @@ export type {
   SeasonPlayerStats,
   SeasonRoundQuery,
   Squad,
-  SquadPlayer,
   SquadQuery,
   Team,
   TeamMetricSet,

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -142,24 +142,6 @@ function resolveTimezone(opts: ParseDateOptions): string {
   return DEFAULT_TIMEZONE;
 }
 
-// Legacy aliases — delegate to parseDate
-/** @deprecated Use {@link parseDate} instead. */
-export function parseAflApiDate(iso: string): Date | null {
-  return parseDate(iso);
-}
-/** @deprecated Use {@link parseDate} instead. */
-export function parseAflApiMatchTime(iso: string): Date | null {
-  return parseDate(iso);
-}
-/** @deprecated Use {@link parseDate} instead. */
-export function parseFootyWireDate(dateStr: string, defaultYear?: number): Date | null {
-  return parseDate(dateStr, defaultYear);
-}
-/** @deprecated Use {@link parseDate} instead. */
-export function parseAflTablesDate(dateStr: string): Date | null {
-  return parseDate(dateStr);
-}
-
 /**
  * Format a Date as an AEST/AEDT-aware display string.
  *

--- a/src/lib/team-metrics.ts
+++ b/src/lib/team-metrics.ts
@@ -4,8 +4,17 @@
 
 import type { TeamMetricSet } from "../types";
 
+/**
+ * Mutable companion to {@link TeamMetricSet} for incremental construction.
+ * Parsers fill fields in as they walk a stats table, then hand the finished
+ * set off as a (readonly) `TeamMetricSet` — no casts required.
+ */
+export type MutableTeamMetricSet = {
+  -readonly [K in keyof TeamMetricSet]: TeamMetricSet[K];
+};
+
 /** Build a fully-nullable TeamMetricSet — caller fills in the fields a source supplies. */
-export function emptyMetricSet(): TeamMetricSet {
+export function emptyMetricSet(): MutableTeamMetricSet {
   return {
     kicks: null,
     handballs: null,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,0 +1,82 @@
+/**
+ * Raw upstream response schemas — the `fitzroy/schemas` subpath export.
+ *
+ * These Zod schemas mirror the AFL API and Squiggle wire formats
+ * verbatim, so they change whenever the upstreams do. They moved out of
+ * the package root in v3 so that upstream drift no longer forces a
+ * major release of the core API; depend on this subpath only if you
+ * are deliberately coupling to the raw wire shapes.
+ *
+ * @packageDocumentation
+ */
+
+export {
+  type SquiggleGame,
+  SquiggleGameSchema,
+  type SquiggleGamesResponse,
+  SquiggleGamesResponseSchema,
+  type SquiggleStanding,
+  SquiggleStandingSchema,
+  type SquiggleStandingsResponse,
+  SquiggleStandingsResponseSchema,
+} from "./lib/squiggle-validation";
+export {
+  type AflApiToken,
+  AflApiTokenSchema,
+  type CfsMatch,
+  CfsMatchSchema,
+  type CfsMatchTeam,
+  CfsMatchTeamSchema,
+  type CfsScore,
+  CfsScoreSchema,
+  type CfsVenue,
+  CfsVenueSchema,
+  type Competition,
+  type CompetitionList,
+  CompetitionListSchema,
+  CompetitionSchema,
+  type Compseason,
+  type CompseasonList,
+  CompseasonListSchema,
+  CompseasonSchema,
+  type LadderEntryRaw,
+  LadderEntryRawSchema,
+  type LadderResponse,
+  LadderResponseSchema,
+  type MatchItem,
+  type MatchItemList,
+  MatchItemListSchema,
+  MatchItemSchema,
+  type MatchRoster,
+  MatchRosterSchema,
+  type PeriodScore,
+  PeriodScoreSchema,
+  type PlayerGameStats,
+  PlayerGameStatsSchema,
+  type PlayerStatsItem,
+  PlayerStatsItemSchema,
+  type PlayerStatsList,
+  PlayerStatsListSchema,
+  type RosterPlayer,
+  RosterPlayerSchema,
+  type Round,
+  type RoundList,
+  RoundListSchema,
+  RoundSchema,
+  type Score,
+  ScoreSchema,
+  type SquadList,
+  SquadListSchema,
+  SquadPlayerInnerSchema,
+  type SquadPlayerItem,
+  SquadPlayerItemSchema,
+  SquadSchema,
+  type TeamItem,
+  TeamItemSchema,
+  type TeamList,
+  TeamListSchema,
+  type TeamPlayers,
+  TeamPlayersSchema,
+  type TeamScore,
+  TeamScoreSchema,
+} from "./lib/validation";

--- a/src/sources/adapters/afl-api.ts
+++ b/src/sources/adapters/afl-api.ts
@@ -27,6 +27,7 @@ import type {
   Player,
   PlayerStats,
   PlayerStatsQuery,
+  SeasonPlayerStats,
   Squad,
   SquadQuery,
 } from "../../types";
@@ -77,7 +78,7 @@ export class AflApiPlayerStatsSource implements PlayerStatsSource {
 
   constructor(private readonly client: AflApiClient = new AflApiClient()) {}
 
-  async fetchPlayerStats(query: PlayerStatsQuery): Promise<Result<PlayerStats[], Error>> {
+  async fetchPlayerStats(query: PlayerStatsQuery): Promise<Result<SeasonPlayerStats, Error>> {
     const competition = query.competition ?? "AFLM";
 
     if (query.matchId) {
@@ -94,8 +95,8 @@ export class AflApiPlayerStatsSource implements PlayerStatsSource {
         teamIdMap.set(match.awayTeamId, normaliseTeamName(match.awayTeam.name));
       }
 
-      return ok(
-        transformPlayerStats(statsResult.data, {
+      return ok({
+        stats: transformPlayerStats(statsResult.data, {
           matchId: query.matchId,
           season: query.season,
           roundNumber: query.round ?? 0,
@@ -103,7 +104,8 @@ export class AflApiPlayerStatsSource implements PlayerStatsSource {
           source: "afl-api",
           teamIdMap,
         }),
-      );
+        failedMatchIds: [],
+      });
     }
 
     const seasonResult = await this.client.resolveCompSeason(competition, query.season);
@@ -125,6 +127,10 @@ export class AflApiPlayerStatsSource implements PlayerStatsSource {
       this.client.fetchPlayerStats(item.match.matchId),
     );
 
+    // Unlike the scraper sources, a single failed match here fails the whole
+    // season — the AFL API is a structured endpoint where per-match failures
+    // indicate a real problem rather than routine scrape flakiness, so the
+    // envelope's failedMatchIds stays empty for this source.
     const allStats: PlayerStats[] = [];
     for (let i = 0; i < statsResults.length; i++) {
       const statsResult = statsResults[i];
@@ -148,7 +154,7 @@ export class AflApiPlayerStatsSource implements PlayerStatsSource {
       );
     }
 
-    return ok(allStats);
+    return ok({ stats: allStats, failedMatchIds: [] });
   }
 }
 

--- a/src/sources/adapters/afl-tables.ts
+++ b/src/sources/adapters/afl-tables.ts
@@ -15,8 +15,8 @@ import type {
   Match,
   MatchQuery,
   Player,
-  PlayerStats,
   PlayerStatsQuery,
+  SeasonPlayerStats,
   Squad,
   SquadQuery,
   TeamStatsEntry,
@@ -61,11 +61,17 @@ export class AflTablesPlayerStatsSource implements PlayerStatsSource {
 
   constructor(private readonly client: AflTablesClient = new AflTablesClient()) {}
 
-  async fetchPlayerStats(query: PlayerStatsQuery): Promise<Result<PlayerStats[], Error>> {
+  async fetchPlayerStats(query: PlayerStatsQuery): Promise<Result<SeasonPlayerStats, Error>> {
     const result = await this.client.fetchSeasonPlayerStats(query.season);
     if (!result.success) return result;
     if (query.round != null) {
-      return ok(result.data.filter((s) => s.roundNumber === query.round));
+      // failedMatchIds pass through unfiltered — a failed game's round is
+      // unknown, so callers see every season-scrape failure regardless of
+      // the round filter.
+      return ok({
+        stats: result.data.stats.filter((s) => s.roundNumber === query.round),
+        failedMatchIds: result.data.failedMatchIds,
+      });
     }
     return result;
   }

--- a/src/sources/adapters/capabilities.ts
+++ b/src/sources/adapters/capabilities.ts
@@ -22,8 +22,8 @@ import type {
   LineupQuery,
   Match,
   MatchQuery,
-  PlayerStats,
   PlayerStatsQuery,
+  SeasonPlayerStats,
   Squad,
   SquadQuery,
   TeamStatsEntry,
@@ -48,9 +48,16 @@ export interface MatchSource extends CapabilityAdapter {
   fetchMatches(query: MatchQuery): Promise<Result<Match[], Error>>;
 }
 
-/** A source that can fetch per-player per-match performance stats. */
+/**
+ * A source that can fetch per-player per-match performance stats.
+ *
+ * Returns a {@link SeasonPlayerStats} partial-result envelope: season-level
+ * scrapes that lose individual games still succeed, with the lost games
+ * listed in `failedMatchIds`. Sources without per-game fetches (or
+ * single-match queries) return an empty `failedMatchIds`.
+ */
 export interface PlayerStatsSource extends CapabilityAdapter {
-  fetchPlayerStats(query: PlayerStatsQuery): Promise<Result<PlayerStats[], Error>>;
+  fetchPlayerStats(query: PlayerStatsQuery): Promise<Result<SeasonPlayerStats, Error>>;
 }
 
 /** A source that can fetch season-aggregated team performance. */

--- a/src/sources/adapters/footywire.ts
+++ b/src/sources/adapters/footywire.ts
@@ -14,6 +14,7 @@ import type {
   Player,
   PlayerStats,
   PlayerStatsQuery,
+  SeasonPlayerStats,
   Squad,
   SquadQuery,
   TeamStatsEntry,
@@ -51,7 +52,9 @@ export class FootyWireMatchSource implements MatchSource {
  * FootyWire as a PlayerStatsSource (AFLM only, ~2010+).
  *
  * Scrapes per-match stats sequentially in batches of 5 with a delay
- * between batches to be respectful to the FootyWire site.
+ * between batches to be respectful to the FootyWire site. Individual
+ * match failures don't abort the scrape — they are surfaced in the
+ * envelope's `failedMatchIds` (same `FW_…` namespace as the stat rows).
  */
 export class FootyWirePlayerStatsSource implements PlayerStatsSource {
   readonly id = "footywire" as const;
@@ -59,7 +62,7 @@ export class FootyWirePlayerStatsSource implements PlayerStatsSource {
 
   constructor(private readonly client: FootyWireClient = new FootyWireClient()) {}
 
-  async fetchPlayerStats(query: PlayerStatsQuery): Promise<Result<PlayerStats[], Error>> {
+  async fetchPlayerStats(query: PlayerStatsQuery): Promise<Result<SeasonPlayerStats, Error>> {
     const idsResult = await this.client.fetchSeasonMatchIds(query.season);
     if (!idsResult.success) return idsResult;
 
@@ -68,7 +71,7 @@ export class FootyWirePlayerStatsSource implements PlayerStatsSource {
         ? idsResult.data.filter((e) => e.roundNumber === query.round)
         : idsResult.data;
 
-    if (entries.length === 0) return ok([]);
+    if (entries.length === 0) return ok({ stats: [], failedMatchIds: [] });
 
     const results = await batchedMap(
       entries,
@@ -77,12 +80,17 @@ export class FootyWirePlayerStatsSource implements PlayerStatsSource {
     );
 
     const allStats: PlayerStats[] = [];
-    for (const result of results) {
-      if (result.success) {
+    const failedMatchIds: string[] = [];
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      const entry = entries[i];
+      if (result?.success) {
         allStats.push(...result.data);
+      } else if (entry) {
+        failedMatchIds.push(`FW_${entry.matchId}`);
       }
     }
-    return ok(allStats);
+    return ok({ stats: allStats, failedMatchIds });
   }
 }
 

--- a/src/sources/adapters/fryzigg.ts
+++ b/src/sources/adapters/fryzigg.ts
@@ -5,9 +5,9 @@
  * no match results, ladders, or squads. Coverage: AFLM and AFLW.
  */
 
-import type { Result } from "../../lib/result";
+import { Result } from "../../lib/result";
 import { transformFryziggPlayerStats } from "../../transforms/fryzigg-player-stats";
-import type { PlayerStats, PlayerStatsQuery } from "../../types";
+import type { PlayerStatsQuery, SeasonPlayerStats } from "../../types";
 import { FryziggClient } from "../fryzigg";
 import type { PlayerStatsSource } from "./capabilities";
 import type { CoverageMap } from "./coverage";
@@ -29,14 +29,17 @@ export class FryziggPlayerStatsSource implements PlayerStatsSource {
 
   constructor(private readonly client: FryziggClient = new FryziggClient()) {}
 
-  async fetchPlayerStats(query: PlayerStatsQuery): Promise<Result<PlayerStats[], Error>> {
+  async fetchPlayerStats(query: PlayerStatsQuery): Promise<Result<SeasonPlayerStats, Error>> {
     const competition = query.competition ?? "AFLM";
     const result = await this.client.fetchPlayerStats(competition);
     if (!result.success) return result;
-    return transformFryziggPlayerStats(result.data, {
+    const transformed = transformFryziggPlayerStats(result.data, {
       competition,
       season: query.season,
       round: query.round,
     });
+    // Fryzigg is a single bulk download — there are no per-game fetches
+    // that can partially fail, so failedMatchIds is always empty.
+    return Result.map(transformed, (stats) => ({ stats, failedMatchIds: [] }));
   }
 }

--- a/src/sources/afl-api.ts
+++ b/src/sources/afl-api.ts
@@ -327,8 +327,10 @@ export class AflApiClient {
       return result;
     }
 
-    const yearStr = String(year);
-    const season = result.data.compSeasons.find((cs) => cs.name.includes(yearStr));
+    // Anchor the year with word boundaries — a bare substring match would
+    // also hit a year embedded in a longer number (COR-10).
+    const yearPattern = new RegExp(`\\b${String(year)}\\b`);
+    const season = result.data.compSeasons.find((cs) => yearPattern.test(cs.name));
 
     if (!season) {
       return err(new AflApiError(`Season not found for year: ${year}`));

--- a/src/sources/afl-tables.ts
+++ b/src/sources/afl-tables.ts
@@ -23,6 +23,7 @@ import type {
   PlayerStats,
   QuarterScore,
   RoundType,
+  SeasonPlayerStats,
   TeamMetricSet,
   TeamStatsEntry,
 } from "../types";
@@ -79,11 +80,16 @@ export class AflTablesClient {
   /**
    * Fetch player statistics for an entire season from AFL Tables.
    *
-   * Scrapes individual game pages linked from the season page.
+   * Scrapes individual game pages linked from the season page. Individual
+   * game failures do not abort the season scrape — they are surfaced in
+   * the returned envelope's `failedMatchIds` instead, so callers can tell
+   * a complete season apart from a partial one. Failure to fetch the
+   * season page itself is still a total `err`.
    *
    * @param year - The season year.
+   * @returns Envelope of scraped stats plus the match IDs that failed.
    */
-  async fetchSeasonPlayerStats(year: number): Promise<Result<PlayerStats[], ScrapeError>> {
+  async fetchSeasonPlayerStats(year: number): Promise<Result<SeasonPlayerStats, ScrapeError>> {
     const seasonUrl = `${AFL_TABLES_BASE}/${year}.html`;
     try {
       const seasonResponse = await this.fetchFn(seasonUrl, {
@@ -103,35 +109,44 @@ export class AflTablesClient {
       const gameUrls = extractGameUrls(seasonHtml);
 
       if (gameUrls.length === 0) {
-        return ok([]);
+        return ok({ stats: [], failedMatchIds: [] });
       }
 
       const results = parseSeasonPage(seasonHtml, year);
 
       const indexedUrls = gameUrls.map((gameUrl, idx) => ({ gameUrl, idx }));
-      const perGameStats = await batchedMap(
+      const perGame = await batchedMap(
         indexedUrls,
-        async ({ gameUrl, idx }) => {
+        async ({
+          gameUrl,
+          idx,
+        }): Promise<{ stats: PlayerStats[]; failedMatchId: string | null }> => {
+          const urlMatch = /\/(\d+)\.html$/.exec(gameUrl);
+          const matchId = urlMatch?.[1] ?? `${year}_${idx}`;
           try {
             const resp = await this.fetchFn(gameUrl, {
               headers: { "User-Agent": "Mozilla/5.0" },
             });
-            if (!resp.ok) return [];
+            if (!resp.ok) return { stats: [], failedMatchId: `AT_${matchId}` };
 
             const html = await resp.text();
-            const urlMatch = /\/(\d+)\.html$/.exec(gameUrl);
-            const matchId = urlMatch?.[1] ?? `${year}_${idx}`;
             const roundNumber = results[idx]?.roundNumber ?? 0;
 
-            return parseAflTablesGameStats(html, matchId, year, roundNumber);
+            return {
+              stats: parseAflTablesGameStats(html, matchId, year, roundNumber),
+              failedMatchId: null,
+            };
           } catch {
-            return [];
+            return { stats: [], failedMatchId: `AT_${matchId}` };
           }
         },
         { batchSize: 5, delayMs: 300 },
       );
 
-      return ok(perGameStats.flat());
+      return ok({
+        stats: perGame.flatMap((g) => g.stats),
+        failedMatchIds: perGame.flatMap((g) => (g.failedMatchId ? [g.failedMatchId] : [])),
+      });
     } catch (cause) {
       return err(
         new ScrapeError(

--- a/src/sources/afl-tables.ts
+++ b/src/sources/afl-tables.ts
@@ -12,7 +12,7 @@ import { parseHtml } from "../lib/parse-html";
 import { err, ok, type Result } from "../lib/result";
 import { createSourceFetch, type SourceFetchOptions } from "../lib/source-fetch";
 import { normaliseTeamName } from "../lib/team-mapping";
-import { emptyMetricSet } from "../lib/team-metrics";
+import { emptyMetricSet, type MutableTeamMetricSet } from "../lib/team-metrics";
 import { normaliseVenueName } from "../lib/venue-mapping";
 import { resolveVenueTimezone } from "../lib/venue-timezones";
 import { extractGameUrls, parseAflTablesGameStats } from "../transforms/afl-tables-player-stats";
@@ -624,8 +624,8 @@ const AFL_TABLES_TEAM_METRIC_MAP: Readonly<Record<string, keyof TeamMetricSet>> 
 
 interface AflTablesTeamData {
   gamesPlayed: number;
-  forMetrics: Record<string, number | null>;
-  againstMetrics: Record<string, number | null>;
+  forMetrics: MutableTeamMetricSet;
+  againstMetrics: MutableTeamMetricSet;
 }
 
 export function parseAflTablesTeamStats(html: string, year: number): TeamStatsEntry[] {
@@ -665,8 +665,8 @@ export function parseAflTablesTeamStats(html: string, year: number): TeamStatsEn
       if (!teamMap.has(teamName)) {
         teamMap.set(teamName, {
           gamesPlayed: 0,
-          forMetrics: { ...emptyMetricSet() },
-          againstMetrics: { ...emptyMetricSet() },
+          forMetrics: emptyMetricSet(),
+          againstMetrics: emptyMetricSet(),
         });
       }
       const entry = teamMap.get(teamName);
@@ -702,8 +702,8 @@ export function parseAflTablesTeamStats(html: string, year: number): TeamStatsEn
       competition: "AFLM",
       team,
       gamesPlayed: data.gamesPlayed,
-      for: data.forMetrics as unknown as TeamMetricSet,
-      against: data.againstMetrics as unknown as TeamMetricSet,
+      for: data.forMetrics,
+      against: data.againstMetrics,
       source: "afl-tables",
     });
   }

--- a/src/sources/afl-tables.ts
+++ b/src/sources/afl-tables.ts
@@ -112,7 +112,15 @@ export class AflTablesClient {
         return ok({ stats: [], failedMatchIds: [] });
       }
 
-      const results = parseSeasonPage(seasonHtml, year);
+      // Key the round lookup by AFL Tables game id, NOT by array index —
+      // the season parse may skip a malformed row, and an index-based
+      // alignment would then shift every later game's round (COR-10).
+      const roundByGameId = new Map<string, number>();
+      for (const game of parseSeasonPageGames(seasonHtml, year)) {
+        if (game.gameId != null) {
+          roundByGameId.set(game.gameId, game.match.roundNumber);
+        }
+      }
 
       const indexedUrls = gameUrls.map((gameUrl, idx) => ({ gameUrl, idx }));
       const perGame = await batchedMap(
@@ -122,7 +130,8 @@ export class AflTablesClient {
           idx,
         }): Promise<{ stats: PlayerStats[]; failedMatchId: string | null }> => {
           const urlMatch = /\/(\d+)\.html$/.exec(gameUrl);
-          const matchId = urlMatch?.[1] ?? `${year}_${idx}`;
+          const gameId = urlMatch?.[1];
+          const matchId = gameId ?? `${year}_${idx}`;
           try {
             const resp = await this.fetchFn(gameUrl, {
               headers: { "User-Agent": "Mozilla/5.0" },
@@ -130,7 +139,7 @@ export class AflTablesClient {
             if (!resp.ok) return { stats: [], failedMatchId: `AT_${matchId}` };
 
             const html = await resp.text();
-            const roundNumber = results[idx]?.roundNumber ?? 0;
+            const roundNumber = (gameId != null ? roundByGameId.get(gameId) : undefined) ?? 0;
 
             return {
               stats: parseAflTablesGameStats(html, matchId, year, roundNumber),
@@ -248,8 +257,29 @@ export class AflTablesClient {
  * @returns Array of match results extracted from the page.
  */
 export function parseSeasonPage(html: string, year: number): Match[] {
+  return parseSeasonPageGames(html, year).map((g) => g.match);
+}
+
+/** A season-page match plus the AFL Tables game id from its "Match stats" link. */
+interface SeasonPageGame {
+  readonly match: Match;
+  /**
+   * Numeric game id extracted from the away row's `stats/games/YYYY/<id>.html`
+   * link, or null when the row carries no stats link. Used to key the
+   * per-game round lookup in {@link AflTablesClient.fetchSeasonPlayerStats} —
+   * keying by array index breaks as soon as one season-page row is skipped.
+   */
+  readonly gameId: string | null;
+}
+
+/**
+ * Parse the season page into matches paired with their AFL Tables game ids.
+ * Internal companion to {@link parseSeasonPage}.
+ */
+function parseSeasonPageGames(html: string, year: number): SeasonPageGame[] {
   const $ = parseHtml(html);
   const results: Match[] = [];
+  const gameIds: (string | null)[] = [];
   let currentRound = 0;
   let currentRoundType: RoundType = "HomeAndAway";
   let currentRoundName = "";
@@ -331,6 +361,12 @@ export function parseSeasonPage(html: string, year: number): Match[] {
 
     matchCounter++;
 
+    // Game id from the away row's "Match stats" link (when present) — keys
+    // the round lookup for the per-game player-stats scrape.
+    const statsCellHtml = $(awayCells[3]).html() ?? "";
+    const gameIdMatch = /\/games\/\d{4}\/(\d+)\.html/.exec(statsCellHtml);
+    gameIds.push(gameIdMatch?.[1] ?? null);
+
     results.push({
       matchId: `AT_${year}_${matchCounter}`,
       season: year,
@@ -373,7 +409,11 @@ export function parseSeasonPage(html: string, year: number): Match[] {
     });
   });
 
-  return remapOpeningRound(results, year);
+  // remapOpeningRound preserves order and length, so re-zip by index.
+  return remapOpeningRound(results, year).map((match, i) => ({
+    match,
+    gameId: gameIds[i] ?? null,
+  }));
 }
 
 /**
@@ -480,7 +520,9 @@ function parseQuarterScores(text: string): (QuarterScore | undefined)[] {
  */
 function parseDateFromInfo(text: string, year: number, venueTimezone: string | null): Date {
   const m = /(\d{1,2})-([A-Z][a-z]{2})-(\d{4})(?:\s+(\d{1,2}):(\d{2})\s*([AaPp][Mm]))?/.exec(text);
-  if (!m) return parseDate(text) ?? new Date(year, 0, 1);
+  // Fallbacks use Date.UTC — `new Date(year, 0, 1)` would depend on the
+  // host machine's local timezone (COR-10).
+  if (!m) return parseDate(text) ?? new Date(Date.UTC(year, 0, 1));
 
   const day = Number.parseInt(m[1] ?? "0", 10);
   const monthStr = (m[2] ?? "").toLowerCase();
@@ -500,7 +542,7 @@ function parseDateFromInfo(text: string, year: number, venueTimezone: string | n
     dec: 11,
   };
   const monthIndex = months[monthStr];
-  if (monthIndex == null) return parseDate(text) ?? new Date(year, 0, 1);
+  if (monthIndex == null) return parseDate(text) ?? new Date(Date.UTC(year, 0, 1));
 
   // No time → midnight UTC (matches AFL Tables' historical convention pre-2010s).
   if (!m[4] || !m[5] || !m[6]) {

--- a/src/sources/footywire.ts
+++ b/src/sources/footywire.ts
@@ -630,7 +630,7 @@ export function parseFootyWireTeamStats(html: string, _year: number): FootyWireD
     const parseNum = (cell: ReturnType<typeof $>) => Number.parseFloat(cell.text().trim()) || 0;
 
     const gamesPlayed = parseNum($(cells[2]));
-    const metrics: Record<string, number | null> = { ...emptyMetricSet() };
+    const metrics = emptyMetricSet();
 
     // Columns 3-19 (0-indexed) map to FOOTYWIRE_STAT_KEYS
     for (let i = 0; i < FOOTYWIRE_STAT_KEYS.length; i++) {
@@ -644,7 +644,7 @@ export function parseFootyWireTeamStats(html: string, _year: number): FootyWireD
     entries.push({
       team: teamName,
       gamesPlayed,
-      metrics: metrics as unknown as TeamMetricSet,
+      metrics,
     });
   });
 

--- a/src/sources/footywire.ts
+++ b/src/sources/footywire.ts
@@ -387,12 +387,10 @@ export function parseMatchList(html: string, year: number): Match[] {
       parseDate(dateText, { defaultYear: year, venue: canonicalVenue }) ??
       new Date(Date.UTC(year, 0, 1));
 
-    // Estimate goals/behinds (FootyWire only gives total score on this page)
-    const homeGoals = Math.floor(homePoints / 6);
-    const homeBehinds = homePoints - homeGoals * 6;
-    const awayGoals = Math.floor(awayPoints / 6);
-    const awayBehinds = awayPoints - awayGoals * 6;
-
+    // FootyWire's match-list page only carries total points — goals/behinds
+    // are NOT published there. They used to be fabricated from the total
+    // (floor(points / 6)), producing plausible-but-wrong data; emit null
+    // instead so the gap is honest (COR-04).
     results.push({
       matchId,
       season: year,
@@ -403,11 +401,11 @@ export function parseMatchList(html: string, year: number): Match[] {
       venue: canonicalVenue,
       homeTeam,
       awayTeam,
-      homeGoals,
-      homeBehinds,
+      homeGoals: null,
+      homeBehinds: null,
       homePoints,
-      awayGoals,
-      awayBehinds,
+      awayGoals: null,
+      awayBehinds: null,
       awayPoints,
       margin: homePoints - awayPoints,
       q1Home: null,
@@ -495,8 +493,11 @@ export function parseFixtureList(html: string, year: number): Match[] {
     gameNumber++;
 
     // Check if we have a score (match played) or not (upcoming).
-    // When present, populate homePoints/awayPoints + estimated goals/behinds
-    // so completed matches don't return as score-less. (#122)
+    // When present, populate homePoints/awayPoints so completed matches
+    // don't return as score-less (#122). Goals/behinds stay null: the
+    // match-list page only publishes total points, and the old
+    // floor(points / 6) estimate fabricated plausible-but-wrong values
+    // (COR-04).
     const scoreCell = cells.length >= 5 ? $(cells[4]) : null;
     const scoreText = scoreCell?.text().trim() ?? "";
     const scoreMatch = /(\d+)-(\d+)/.exec(scoreText);
@@ -504,18 +505,10 @@ export function parseFixtureList(html: string, year: number): Match[] {
 
     let homePoints: number | null = null;
     let awayPoints: number | null = null;
-    let homeGoals: number | null = null;
-    let homeBehinds: number | null = null;
-    let awayGoals: number | null = null;
-    let awayBehinds: number | null = null;
     let margin: number | null = null;
     if (scoreMatch) {
       homePoints = Number.parseInt(scoreMatch[1] ?? "0", 10);
       awayPoints = Number.parseInt(scoreMatch[2] ?? "0", 10);
-      homeGoals = Math.floor(homePoints / 6);
-      homeBehinds = homePoints - homeGoals * 6;
-      awayGoals = Math.floor(awayPoints / 6);
-      awayBehinds = awayPoints - awayGoals * 6;
       margin = homePoints - awayPoints;
     }
 
@@ -529,11 +522,11 @@ export function parseFixtureList(html: string, year: number): Match[] {
       venue: canonicalVenue,
       homeTeam,
       awayTeam,
-      homeGoals,
-      homeBehinds,
+      homeGoals: null,
+      homeBehinds: null,
       homePoints,
-      awayGoals,
-      awayBehinds,
+      awayGoals: null,
+      awayBehinds: null,
       awayPoints,
       margin,
       q1Home: null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,6 +249,26 @@ export interface PlayerStats {
   readonly source: DataSource;
 }
 
+/**
+ * Partial-result envelope returned by season-level player-stats fetches.
+ *
+ * Season scrapes hit one page per game, so a single failed game should not
+ * discard the rest of the season — but it must not be silent either. The
+ * envelope carries both the stat lines that were scraped and the IDs of
+ * matches whose per-game scrape failed. IDs share the namespace of
+ * {@link PlayerStats.matchId} (e.g. `AT_…` for AFL Tables, `FW_…` for
+ * FootyWire) so failures can be cross-referenced against returned rows.
+ *
+ * Total failure of the season-level request itself (e.g. the season page
+ * is unreachable) is still reported as an `err` Result, not an envelope.
+ */
+export interface SeasonPlayerStats {
+  /** Per-player stat lines for every game that was fetched successfully. */
+  readonly stats: readonly PlayerStats[];
+  /** Match IDs whose per-game fetch or parse failed (empty when complete). */
+  readonly failedMatchIds: readonly string[];
+}
+
 // ---------------------------------------------------------------------------
 // Lineup / roster
 // ---------------------------------------------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,12 @@ export interface Match {
   /**
    * Total goals-behinds-points for each team. Null when the match has not
    * yet been played (status="Upcoming").
+   *
+   * FootyWire match-list rows (`source: "footywire"`) always carry null
+   * goals/behinds — the match-list page only publishes total points, so
+   * only `homePoints`/`awayPoints` are populated for that source. Use the
+   * per-match stats pages (or another source) when you need the
+   * goals-behinds breakdown.
    */
   readonly homeGoals: number | null;
   readonly homeBehinds: number | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -387,13 +387,6 @@ export interface Player {
   readonly competition: CompetitionCode;
 }
 
-/**
- * @deprecated Use {@link Player}. Removed in 2.1.0; alias retained
- * temporarily for downstream type-only references. Will be deleted in
- * 3.0.
- */
-export type SquadPlayer = Player;
-
 /** A team's squad for a given season. */
 export interface Squad {
   readonly teamId: string;

--- a/test/lib/date-utils.test.ts
+++ b/test/lib/date-utils.test.ts
@@ -1,16 +1,8 @@
 import { describe, expect, it } from "vitest";
-import {
-  localToUtc,
-  parseAflApiDate,
-  parseAflApiMatchTime,
-  parseAflTablesDate,
-  parseDate,
-  parseFootyWireDate,
-  toAestString,
-} from "../../src/lib/date-utils";
+import { localToUtc, parseDate, toAestString } from "../../src/lib/date-utils";
 import { DstGapError } from "../../src/lib/errors";
 
-describe("parseDate", () => {
+describe("parseDate (canonical)", () => {
   // AFL API — ISO without Z (utcStartTime)
   it("parses AFL API datetime without Z as UTC", () => {
     expect(parseDate("2026-03-05T08:30:00")?.toISOString()).toBe("2026-03-05T08:30:00.000Z");
@@ -57,56 +49,48 @@ describe("parseDate", () => {
   });
 });
 
-describe("parseAflApiDate", () => {
+describe("parseDate — AFL API ISO inputs", () => {
   it.each([
     ["2024-03-14T06:20:00.000Z", "2024-03-14T06:20:00.000Z"],
     ["2024-03-14T06:20:00Z", "2024-03-14T06:20:00.000Z"],
     ["2024-03-14", undefined], // valid but year-only check below
   ])("parses %s", (input, expectedIso) => {
-    const date = parseAflApiDate(input);
+    const date = parseDate(input);
     expect(date).toBeInstanceOf(Date);
     if (expectedIso) expect(date?.toISOString()).toBe(expectedIso);
     else expect(date?.getUTCFullYear()).toBe(2024);
   });
 
   it.each(["not-a-date", ""])("returns null for %j", (input) => {
-    expect(parseAflApiDate(input)).toBeNull();
+    expect(parseDate(input)).toBeNull();
   });
 });
 
-describe("parseAflApiMatchTime", () => {
+describe("parseDate — AFL API match times", () => {
   it("parses UTC string without Z suffix correctly", () => {
     // AFL API returns UTC times without Z — must not be treated as local time
-    expect(parseAflApiMatchTime("2026-03-05T08:30:00")?.toISOString()).toBe(
-      "2026-03-05T08:30:00.000Z",
-    );
+    expect(parseDate("2026-03-05T08:30:00")?.toISOString()).toBe("2026-03-05T08:30:00.000Z");
   });
 
   it("parses UTC string with Z suffix correctly", () => {
-    expect(parseAflApiMatchTime("2026-03-05T08:30:00Z")?.toISOString()).toBe(
-      "2026-03-05T08:30:00.000Z",
-    );
+    expect(parseDate("2026-03-05T08:30:00Z")?.toISOString()).toBe("2026-03-05T08:30:00.000Z");
   });
 
   it("parses UTC string with milliseconds", () => {
-    expect(parseAflApiMatchTime("2026-07-04T09:30:00.000Z")?.toISOString()).toBe(
-      "2026-07-04T09:30:00.000Z",
-    );
+    expect(parseDate("2026-07-04T09:30:00.000Z")?.toISOString()).toBe("2026-07-04T09:30:00.000Z");
   });
 
   it("strips timezone offset if present", () => {
-    expect(parseAflApiMatchTime("2026-03-05T08:30:00+00:00")?.toISOString()).toBe(
-      "2026-03-05T08:30:00.000Z",
-    );
+    expect(parseDate("2026-03-05T08:30:00+00:00")?.toISOString()).toBe("2026-03-05T08:30:00.000Z");
   });
 
   it("returns null for invalid input", () => {
-    expect(parseAflApiMatchTime("not-a-date")).toBeNull();
-    expect(parseAflApiMatchTime("")).toBeNull();
+    expect(parseDate("not-a-date")).toBeNull();
+    expect(parseDate("")).toBeNull();
   });
 });
 
-describe("parseFootyWireDate", () => {
+describe("parseDate — FootyWire inputs", () => {
   it.each([
     ["Sat 16 Mar 2024", "2024-03-16T00:00:00.000Z"],
     ["16 Mar 2024", "2024-03-16T00:00:00.000Z"],
@@ -116,41 +100,41 @@ describe("parseFootyWireDate", () => {
     ["16 March 2024", "2024-03-16T00:00:00.000Z"],
     ["  16 Mar 2024  ", "2024-03-16T00:00:00.000Z"],
   ])("parses %j → %s", (input, expectedIso) => {
-    expect(parseFootyWireDate(input)?.toISOString()).toBe(expectedIso);
+    expect(parseDate(input)?.toISOString()).toBe(expectedIso);
   });
 
   it.each(["", "2024/03/16", "30 Feb 2024"])("returns null for %j (no defaultYear)", (input) => {
-    expect(parseFootyWireDate(input)).toBeNull();
+    expect(parseDate(input)).toBeNull();
   });
 
   it("parses time during AEDT (UTC+11) correctly", () => {
     // March 13 2025 is during AEDT — 7:30pm AEDT = 08:30 UTC
-    const date = parseFootyWireDate("Thu 13 Mar 7:30pm", 2025);
+    const date = parseDate("Thu 13 Mar 7:30pm", 2025);
     expect(date?.toISOString()).toBe("2025-03-13T08:30:00.000Z");
   });
 
   it("parses time during AEST (UTC+10) correctly", () => {
     // July 13 2025 is during AEST — 7:30pm AEST = 09:30 UTC
-    const date = parseFootyWireDate("13 Jul 7:30pm", 2025);
+    const date = parseDate("13 Jul 7:30pm", 2025);
     expect(date?.toISOString()).toBe("2025-07-13T09:30:00.000Z");
   });
 
   it("parses date-only with defaultYear", () => {
-    expect(parseFootyWireDate("13 Mar", 2025)?.toISOString()).toBe("2025-03-13T00:00:00.000Z");
+    expect(parseDate("13 Mar", 2025)?.toISOString()).toBe("2025-03-13T00:00:00.000Z");
   });
 
   it("parses am time with defaultYear", () => {
     // April 1 2025 is during AEDT — 11:00am AEDT = 00:00 UTC
-    const date = parseFootyWireDate("1 Apr 11:00am", 2025);
+    const date = parseDate("1 Apr 11:00am", 2025);
     expect(date?.toISOString()).toBe("2025-04-01T00:00:00.000Z");
   });
 
   it.each(["13 Mar 7:30pm", "13 Mar"])("returns null for %j without defaultYear", (input) => {
-    expect(parseFootyWireDate(input)).toBeNull();
+    expect(parseDate(input)).toBeNull();
   });
 });
 
-describe("parseAflTablesDate", () => {
+describe("parseDate — AFL Tables inputs", () => {
   it.each([
     ["16-Mar-2024", "2024-03-16T00:00:00.000Z"],
     ["Sat 16-Mar-2024", "2024-03-16T00:00:00.000Z"],
@@ -158,11 +142,11 @@ describe("parseAflTablesDate", () => {
     ["16/Mar/2024", "2024-03-16T00:00:00.000Z"],
     ["8-May-1897", "1897-05-08T00:00:00.000Z"],
   ])("parses %j → %s", (input, expectedIso) => {
-    expect(parseAflTablesDate(input)?.toISOString()).toBe(expectedIso);
+    expect(parseDate(input)?.toISOString()).toBe(expectedIso);
   });
 
   it.each(["", "2024", "16-Xyz-2024"])("returns null for %j", (input) => {
-    expect(parseAflTablesDate(input)).toBeNull();
+    expect(parseDate(input)).toBeNull();
   });
 });
 

--- a/test/sources/adapters/footywire.test.ts
+++ b/test/sources/adapters/footywire.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { FootyWirePlayerStatsSource } from "../../../src/sources/adapters/footywire";
+import { FootyWireClient } from "../../../src/sources/footywire";
+
+const matchListHtml = readFileSync(
+  resolve(__dirname, "../../fixtures/footywire-match-list.html"),
+  "utf-8",
+);
+const basicStatsHtml = readFileSync(
+  resolve(__dirname, "../../fixtures/footywire-match-stats-basic-11174.html"),
+  "utf-8",
+);
+const advancedStatsHtml = readFileSync(
+  resolve(__dirname, "../../fixtures/footywire-match-stats-advanced-11174.html"),
+  "utf-8",
+);
+
+/**
+ * Build a fetch mock that serves the season match list and per-match stats
+ * pages, failing the stats pages for the given match IDs.
+ */
+function buildFetchFn(failingMids: readonly string[]) {
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("ft_match_list")) {
+      return Promise.resolve(new Response(matchListHtml, { status: 200 }));
+    }
+    if (failingMids.some((mid) => url.includes(`mid=${mid}`))) {
+      return Promise.resolve(new Response("", { status: 404 }));
+    }
+    if (url.includes("advv=Y")) {
+      return Promise.resolve(new Response(advancedStatsHtml, { status: 200 }));
+    }
+    return Promise.resolve(new Response(basicStatsHtml, { status: 200 }));
+  });
+}
+
+describe("FootyWirePlayerStatsSource (COR-03 partial-result envelope)", () => {
+  it("reports a failed match in failedMatchIds while the rest of the season survives", async () => {
+    const client = new FootyWireClient({ fetchFn: buildFetchFn(["11194"]) });
+    const source = new FootyWirePlayerStatsSource(client);
+
+    const result = await source.fetchPlayerStats({ source: "footywire", season: 2025 });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.stats.length).toBeGreaterThan(0);
+    expect(result.data.failedMatchIds).toEqual(["FW_11194"]);
+    // Surviving matches still contribute stat rows.
+    const matchIds = new Set(result.data.stats.map((s) => s.matchId));
+    expect(matchIds.has("FW_11193")).toBe(true);
+    expect(matchIds.has("FW_11194")).toBe(false);
+  });
+
+  it("returns empty failedMatchIds when every match succeeds", async () => {
+    const client = new FootyWireClient({ fetchFn: buildFetchFn([]) });
+    const source = new FootyWirePlayerStatsSource(client);
+
+    const result = await source.fetchPlayerStats({ source: "footywire", season: 2025 });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.stats.length).toBeGreaterThan(0);
+    expect(result.data.failedMatchIds).toEqual([]);
+  });
+
+  it("still returns total err when the match-list page itself fails", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response("", { status: 503 }));
+    const client = new FootyWireClient({ fetchFn });
+    const source = new FootyWirePlayerStatsSource(client);
+
+    const result = await source.fetchPlayerStats({ source: "footywire", season: 2025 });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/test/sources/afl-api.test.ts
+++ b/test/sources/afl-api.test.ts
@@ -298,6 +298,24 @@ describe("AflApiClient", () => {
       }
     });
 
+    it("anchors the year — does not match a year embedded in a longer number (COR-10)", async () => {
+      const compseasons = {
+        compSeasons: [
+          { id: 52, name: "Festival Cup 12024" },
+          { id: 62, name: "2024 Toyota AFL Premiership" },
+        ],
+      };
+      const fetchFn = vi.fn().mockResolvedValueOnce(mockResponse(compseasons));
+      const client = new AflApiClient({ fetchFn });
+
+      const result = await client.resolveSeasonId(1, 2024);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe(62);
+      }
+    });
+
     it("returns error when season year is not found", async () => {
       const compseasons = {
         compSeasons: [{ id: 52, name: "2023 Toyota AFL Premiership" }],

--- a/test/sources/afl-tables.test.ts
+++ b/test/sources/afl-tables.test.ts
@@ -176,5 +176,41 @@ describe("AflTablesClient", () => {
 
       expect(result.success).toBe(false);
     });
+
+    it("keys round numbers by game id, so a skipped season-page row does not shift later rounds (COR-10)", async () => {
+      // Round 1's match table is malformed (no team links) so parseSeasonPage
+      // skips it, but its "Match stats" link is still picked up by the game-URL
+      // extractor. With index-based alignment the Round 2 game would read the
+      // round from results[1] (which doesn't exist) and fall back to 0.
+      const seasonWithSkippedRowHtml = `<html><body>
+<table><tr><td>Round 1</td><td></td></tr></table>
+<table border=1>
+<tr><td>Sydney</td><td><tt>3.3 4.3 7.10 12.14</tt></td><td> 86</td><td>Thu 07-Mar-2023 7:30 PM <b>Venue:</b> <a href="../venues/scg.html">S.C.G.</a></td></tr>
+<tr><td>Melbourne</td><td><tt>1.6 2.8 7.8 9.10</tt></td><td> 64</td><td><b>Sydney</b> won by <b>22 pts </b>[<a href="../stats/games/2023/111620230307.html">Match stats</a>]</td></tr>
+</table>
+<table><tr><td>Round 2</td><td></td></tr></table>
+<table border=1>
+<tr><td><a href="../teams/geelong_idx.html">Geelong</a></td><td><tt>5.1 9.4 12.10 16.12</tt></td><td>108</td><td>Sat 16-Mar-2023 1:45 PM <b>Venue:</b> <a href="../venues/geel.html">K.S.</a></td></tr>
+<tr><td><a href="../teams/adelaide_idx.html">Adelaide</a></td><td><tt>2.3 5.5 8.8 10.11</tt></td><td> 71</td><td><b>Geelong</b> won by <b>37 pts </b>[<a href="../stats/games/2023/031820230316.html">Match stats</a>]</td></tr>
+</table>
+</body></html>`;
+
+      const fetchFn = vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/seas/2023.html")) {
+          return Promise.resolve(new Response(seasonWithSkippedRowHtml, { status: 200 }));
+        }
+        return Promise.resolve(new Response(gameStatsHtml, { status: 200 }));
+      });
+      const client = new AflTablesClient({ fetchFn });
+
+      const result = await client.fetchSeasonPlayerStats(2023);
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      const round2Stats = result.data.stats.filter((s) => s.matchId === "AT_031820230316");
+      expect(round2Stats.length).toBeGreaterThan(0);
+      expect(round2Stats[0]?.roundNumber).toBe(2);
+    });
   });
 });

--- a/test/sources/afl-tables.test.ts
+++ b/test/sources/afl-tables.test.ts
@@ -66,6 +66,23 @@ describe("parseSeasonPage", () => {
   });
 });
 
+// Season page with two matches that BOTH carry "Match stats" game links, so
+// fetchSeasonPlayerStats has two game pages to scrape.
+const seasonWithTwoGameLinksHtml = `<html><body>
+<table><tr><td>Round 1</td><td></td></tr></table>
+<table border=1>
+<tr><td><a href="../teams/swans_idx.html">Sydney</a></td><td><tt>3.3 4.3 7.10 12.14</tt></td><td> 86</td><td>Thu 07-Mar-2024 7:30 PM <b>Att: </b>40,012 <b>Venue:</b> <a href="../venues/scg.html">S.C.G.</a></td></tr>
+<tr><td><a href="../teams/melbourne_idx.html">Melbourne</a></td><td><tt>1.6 2.8 7.8 9.10</tt></td><td> 64</td><td><b>Sydney</b> won by <b>22 pts </b>[<a href="../stats/games/2024/111620240307.html">Match stats</a>]</td></tr>
+</table>
+<table border=1>
+<tr><td><a href="../teams/brisbanel_idx.html">Brisbane Lions</a></td><td><tt>7.2 9.5 10.11 12.13</tt></td><td> 85</td><td>Fri 08-Mar-2024 6:40 PM <b>Att: </b>33,367 <b>Venue:</b> <a href="../venues/gabba.html">Gabba</a></td></tr>
+<tr><td><a href="../teams/carlton_idx.html">Carlton</a></td><td><tt>2.0 4.4 11.6 13.8</tt></td><td> 86</td><td><b>Carlton</b> won by <b>1 pt </b>[<a href="../stats/games/2024/031420240308.html">Match stats</a>]</td></tr>
+</table>
+</body></html>`;
+
+const GAME_STATS_FIXTURE = resolve(__dirname, "../fixtures/afltables-game-stats-2024-r1.html");
+const gameStatsHtml = readFileSync(GAME_STATS_FIXTURE, "utf-8");
+
 describe("AflTablesClient", () => {
   it("fetches and parses season results", async () => {
     const fetchFn = vi.fn().mockResolvedValue(new Response(fixtureHtml, { status: 200 }));
@@ -86,5 +103,78 @@ describe("AflTablesClient", () => {
     const result = await client.fetchSeasonResults(2024);
 
     expect(result.success).toBe(false);
+  });
+
+  describe("fetchSeasonPlayerStats (COR-03 partial-result envelope)", () => {
+    it("reports a failed game in failedMatchIds while the rest of the season survives", async () => {
+      const fetchFn = vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/seas/2024.html")) {
+          return Promise.resolve(new Response(seasonWithTwoGameLinksHtml, { status: 200 }));
+        }
+        if (url.includes("111620240307")) {
+          return Promise.resolve(new Response(gameStatsHtml, { status: 200 }));
+        }
+        // Second game page 404s.
+        return Promise.resolve(new Response("", { status: 404 }));
+      });
+      const client = new AflTablesClient({ fetchFn });
+
+      const result = await client.fetchSeasonPlayerStats(2024);
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.stats.length).toBeGreaterThan(0);
+      expect(result.data.stats[0]?.matchId).toBe("AT_111620240307");
+      expect(result.data.failedMatchIds).toEqual(["AT_031420240308"]);
+    });
+
+    it("reports a game whose fetch throws in failedMatchIds", async () => {
+      const fetchFn = vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/seas/2024.html")) {
+          return Promise.resolve(new Response(seasonWithTwoGameLinksHtml, { status: 200 }));
+        }
+        if (url.includes("111620240307")) {
+          return Promise.resolve(new Response(gameStatsHtml, { status: 200 }));
+        }
+        return Promise.reject(new Error("Network error"));
+      });
+      const client = new AflTablesClient({ fetchFn });
+
+      const result = await client.fetchSeasonPlayerStats(2024);
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.stats.length).toBeGreaterThan(0);
+      expect(result.data.failedMatchIds).toEqual(["AT_031420240308"]);
+    });
+
+    it("returns empty failedMatchIds when every game succeeds", async () => {
+      const fetchFn = vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/seas/2024.html")) {
+          return Promise.resolve(new Response(seasonWithTwoGameLinksHtml, { status: 200 }));
+        }
+        return Promise.resolve(new Response(gameStatsHtml, { status: 200 }));
+      });
+      const client = new AflTablesClient({ fetchFn });
+
+      const result = await client.fetchSeasonPlayerStats(2024);
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.stats.length).toBeGreaterThan(0);
+      expect(result.data.failedMatchIds).toEqual([]);
+    });
+
+    it("still returns total err when the season page itself fails", async () => {
+      const fetchFn = vi.fn().mockResolvedValue(new Response("", { status: 503 }));
+      const client = new AflTablesClient({ fetchFn });
+
+      const result = await client.fetchSeasonPlayerStats(2024);
+
+      expect(result.success).toBe(false);
+    });
   });
 });

--- a/test/sources/footywire.test.ts
+++ b/test/sources/footywire.test.ts
@@ -37,6 +37,19 @@ describe("parseMatchList", () => {
     expect(first.q4Away).toBeNull();
   });
 
+  it("emits null goals/behinds — the match-list page only publishes total points (COR-04)", () => {
+    const results = parseMatchList(fixtureHtml, 2025);
+    const first = results[0];
+    expect(first).toBeDefined();
+    if (!first) return;
+
+    expect(first.homePoints).toBe(82);
+    expect(first.homeGoals).toBeNull();
+    expect(first.homeBehinds).toBeNull();
+    expect(first.awayGoals).toBeNull();
+    expect(first.awayBehinds).toBeNull();
+  });
+
   it("extracts round numbers from headers", () => {
     const results = parseMatchList(fixtureHtml, 2025);
 
@@ -55,7 +68,7 @@ describe("parseMatchList", () => {
 });
 
 describe("parseFixtureList (#122)", () => {
-  it("populates homePoints/awayPoints/margin/goals/behinds when score is present", () => {
+  it("populates homePoints/awayPoints/margin when score is present, leaving goals/behinds null", () => {
     const fixtures = parseFixtureList(fixtureHtml, 2025);
     const completed = fixtures.filter((f) => f.status === "Complete");
     expect(completed.length).toBeGreaterThan(0);
@@ -70,12 +83,13 @@ describe("parseFixtureList (#122)", () => {
     expect(first.homePoints).toBe(82);
     expect(first.awayPoints).toBe(69);
     expect(first.margin).toBe(13);
-    // Goals/behinds estimated from the total (FootyWire match list only
-    // exposes total points): 82 = 13.4, 69 = 11.3
-    expect(first.homeGoals).toBe(13);
-    expect(first.homeBehinds).toBe(4);
-    expect(first.awayGoals).toBe(11);
-    expect(first.awayBehinds).toBe(3);
+    // Goals/behinds are null — the match-list page only publishes total
+    // points, and fabricating them from the total produced wrong data
+    // (COR-04).
+    expect(first.homeGoals).toBeNull();
+    expect(first.homeBehinds).toBeNull();
+    expect(first.awayGoals).toBeNull();
+    expect(first.awayBehinds).toBeNull();
   });
 
   it("leaves scores null for upcoming matches", () => {

--- a/tsconfig.portable.json
+++ b/tsconfig.portable.json
@@ -1,0 +1,12 @@
+// Portability gate (MNT-06): proves the library core (src/ minus the CLI)
+// compiles against Web Standard APIs only — no Node.js type definitions.
+// Run via `npm run typecheck:portable`.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": [],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/cli.ts", "src/cli/**"]
+}


### PR DESCRIPTION
## Summary
Breaking release implementing the architecture review's v3 plan:
- **MNT-04a**: package root trimmed to the supported surface; raw AFL API/Squiggle wire schemas behind the new `fitzroy/schemas` subpath; deprecated date-parse aliases and `SquadPlayer` deleted
- **MNT-04b**: `citty`/`@clack/prompts`/`picocolors` become devDependencies bundled into `dist/cli.js` — library consumers stop installing CLI deps; rds-js bumped to ^0.3.0
- **COR-03**: season player-stats return `SeasonPlayerStats { stats, failedMatchIds }` — silent partial data loss is now visible (CLI warns on failed games)
- **COR-04**: FootyWire match-list rows emit null goals/behinds instead of `floor(points/6)` fabrication
- **COR-10**: round lookup keyed by game id instead of array index; `Date.UTC` fallbacks; anchored compseason year match
- **MNT-06/08**: portable-core typecheck without node types (CI-enforced); ADRs + CONTEXT.md committed; metric-set double-casts removed
- **TST-03/06**: coverage reporting in CI; weekly scraper canary workflow that opens an issue on parser drift

## Test plan
- [x] 373 tests green, typecheck + portable typecheck + biome clean, attw green, CLI smoke-tested from the bundled build
- [ ] CI green → merge
- [ ] Consumer check: AFL-MCP + footyBot build against the packed v3 tarball
- [ ] **Tag v3.0.0 only after changelog review** (publishes to npm via OIDC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)