### PR TITLE
fix: map AFL API pre-game statuses to Upcoming (v3.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] - 2026-06-12
+
+### Fixed
+
+- AFL API matches with pre-game statuses `UNCONFIRMED_TEAMS`,
+  `CONFIRMED_TEAMS` or `PLACEHOLDER` were mapped to `Complete`; they now
+  map to `Upcoming`. Unknown raw statuses also default to `Upcoming`
+  instead of `Complete`, so a new pre-game status can no longer silently
+  hide upcoming fixtures from status-filtered queries.
+
 ## [3.0.0] - 2026-06-11
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fitzroy",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "TypeScript port of the fitzRoy R package — programmatic access to AFL data including match results, player stats, fixtures, ladders, and more",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/transforms/match-results.ts
+++ b/src/transforms/match-results.ts
@@ -75,13 +75,19 @@ export function toMatchStatus(raw: string): MatchStatus {
       return "Live";
     case "UPCOMING":
     case "SCHEDULED":
+    case "UNCONFIRMED_TEAMS":
+    case "CONFIRMED_TEAMS":
+    case "PLACEHOLDER":
       return "Upcoming";
     case "POSTPONED":
       return "Postponed";
     case "CANCELLED":
       return "Cancelled";
     default:
-      return "Complete";
+      // Unknown statuses are far more likely to be new pre-game states
+      // (the API has grown UNCONFIRMED_TEAMS/PLACEHOLDER before) than new
+      // terminal ones; defaulting to Complete silently hid upcoming games.
+      return "Upcoming";
   }
 }
 

--- a/test/transforms/match-results.test.ts
+++ b/test/transforms/match-results.test.ts
@@ -152,6 +152,28 @@ describe("transformMatchItems", () => {
     expect(results[1]?.status).toBe("Live");
   });
 
+  it("maps pre-game team-announcement statuses to Upcoming", () => {
+    // The AFL API reports near-future matches as UNCONFIRMED_TEAMS /
+    // CONFIRMED_TEAMS and far-future finals as PLACEHOLDER. These were
+    // previously swallowed by a default→Complete branch, which made
+    // upcoming games invisible to status-filtered consumers (footyBot
+    // missed live coverage on 2026-06-11).
+    const statuses = ["UNCONFIRMED_TEAMS", "CONFIRMED_TEAMS", "PLACEHOLDER"];
+    for (const status of statuses) {
+      const item = makeMatchItem();
+      item.match.status = status;
+      const results = transformMatchItems([item], 2026, "AFLM");
+      expect(results[0]?.status).toBe("Upcoming");
+    }
+  });
+
+  it("maps unknown statuses to Upcoming, not Complete", () => {
+    const item = makeMatchItem();
+    item.match.status = "SOME_FUTURE_STATUS";
+    const results = transformMatchItems([item], 2026, "AFLM");
+    expect(results[0]?.status).toBe("Upcoming");
+  });
+
   it("handles missing venue", () => {
     const item = makeMatchItem({ venue: undefined });
     const results = transformMatchItems([item], 2025, "AFLM");


### PR DESCRIPTION
## Summary
- `toMatchStatus` maps `UNCONFIRMED_TEAMS`, `CONFIRMED_TEAMS`, `PLACEHOLDER` → `Upcoming`; unknown raw statuses now also default to `Upcoming` instead of `Complete`
- Root cause of footyBot's missed live coverage on 2026-06-11 (empty fixture cached all day) and AFL-MCP storing upcoming matches as `Complete` with null scores
- Regression tests for the three observed statuses and the unknown-status fallback; version bumped to 3.0.1

## Test plan
- [x] `npm run typecheck && npm run check && npm run test` (375 passing)
- [ ] CI green
- [ ] Post-publish: footyBot fixture repro shows tonight's match as `Upcoming`

🤖 Generated with [Claude Code](https://claude.com/claude-code)