### PR TITLE
chore: add Dependabot config + ecosystem-doc checklist

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: npm
-    directory: /
+  - package-ecosystem: "bun"
+    directory: "/"
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
-    labels:
-      - dependencies
-    commit-message:
-      prefix: "deps"
-
-  - package-ecosystem: github-actions
-    directory: /
+      interval: "weekly"
+      day: "monday"
+      timezone: "Australia/Melbourne"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
-    labels:
-      - dependencies
-    commit-message:
-      prefix: "ci"
+      interval: "weekly"
+      day: "monday"
+      timezone: "Australia/Melbourne"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,3 +141,11 @@ This project uses Ralph — an autonomous iteration loop for completing user sto
 ## CHANGELOG.md
 
 Maintain a CHANGELOG.md under `[Unreleased]` using categories: Added, Changed, Deprecated, Removed, Fixed, Security. Only update for user-facing changes — not refactors, tests, docs, or formatting.
+
+## Ecosystem doc
+
+The public ecosystem doc (homepage repo: `public/docs/afl-data-ecosystem.md`,
+served at jackemcpherson.com/docs/afl-data-ecosystem.md) describes this
+project's public surface. If a change alters that surface — exported
+functions/types, data sources or coverage, endpoints, DB schema, CLI
+commands, cron behavior — update the doc in the same sitting.


### PR DESCRIPTION
Hygiene layer of the ops-consolidation round (same change across footyBot, AFL-MCP, tipper, fitzRoy-ts, rds-js):

- `.github/dependabot.yml`: weekly (Mon, Melbourne), grouped minor+patch for bun deps; grouped GitHub Actions bumps. Exact pins (e.g. footyBot's `fitzroy`) get explicit bump PRs instead of silently rotting.
- CLAUDE.md: release-checklist note — public-surface changes must update `public/docs/afl-data-ecosystem.md` in the homepage repo in the same sitting (the doc drifted ~27 claims in a month without this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)